### PR TITLE
Assign new CIDR range and run service in 3 AZs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,9 +43,10 @@ module "label" {
 
 
 locals {
-  private_ip_eu_west_2a = "10.0.0.7"
-  private_ip_eu_west_2b = "10.0.1.6"
-  vpc_cidr              = "10.0.0.0/16"
+  private_ip_eu_west_2a = "10.180.100.5"
+  private_ip_eu_west_2b = "10.180.101.5"
+  private_ip_eu_west_2c = "10.180.102.5"
+  vpc_cidr              = "10.180.100.0/22"
   client_vpc_cidr       = "192.168.0.0/16"
 }
 

--- a/modules/radius/load_balancer.tf
+++ b/modules/radius/load_balancer.tf
@@ -4,15 +4,17 @@ resource "aws_lb" "load_balancer" {
   internal           = false
   subnet_mapping {
     subnet_id = var.public_subnets[0]
-    allocation_id = aws_eip.radius_ip.id
+  }
+
+  subnet_mapping {
+    subnet_id = var.public_subnets[1]
+  }
+
+  subnet_mapping {
+    subnet_id = var.public_subnets[2]
   }
 
   enable_deletion_protection = false
-}
-
-resource "aws_eip" "radius_ip" {
-  vpc              = true
-  public_ipv4_pool = "amazon"
 }
 
 resource "aws_lb_listener" "udp" {

--- a/modules/radius/load_balancer_internal.tf
+++ b/modules/radius/load_balancer_internal.tf
@@ -12,6 +12,11 @@ resource "aws_lb" "internal_load_balancer" {
     private_ipv4_address = var.private_ip_eu_west_2b
   }
 
+  subnet_mapping {
+    subnet_id = var.private_subnets[2]
+    private_ipv4_address = var.private_ip_eu_west_2c
+  }
+
   enable_deletion_protection = false
 }
 

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -26,7 +26,8 @@ module "vpc" {
 
   azs = [
     "eu-west-2a",
-    "eu-west-2b"
+    "eu-west-2b",
+    "eu-west-2c"
   ]
 
   enable_ecr_dkr_endpoint              = true
@@ -55,11 +56,13 @@ module "vpc" {
   default_security_group_egress  = []
   private_subnets = [
     cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 0),
-    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 1)
+    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 2),
+    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 4)
   ]
 
   public_subnets = [
-    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 2),
-    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 3)
+    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 1),
+    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 3),
+    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 5),
   ]
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,10 +1,10 @@
 variable cidr_block {
-    type = string 
+    type = string
 }
 
 variable "cidr_block_new_bits" {
-    type = number 
-    default = 8
+    type = number
+    default = 3
 }
 
 variable "prefix" {


### PR DESCRIPTION
This new range will allow us to integrate with the rest of the MoJ
network without overlapping CIDRs