### PR TITLE
New hosted zone for NAC service

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,6 +6,7 @@ env:
     TF_INPUT: 0
     TF_VAR_owner_email: nac@justice.gov.uk
     TF_VAR_enable_authentication: true
+    TF_VAR_enable_hosted_zone: true
     TF_VAR_enable_nac_transit_gateway_attachment: true
   parameter-store:
     TF_VAR_assume_role: "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/assume_role"

--- a/main.tf
+++ b/main.tf
@@ -67,8 +67,10 @@ module "radius" {
   byoip_pool_id         = var.byoip_pool_id
   ocsp_endpoint_ip      = var.ocsp_endpoint_ip
   ocsp_endpoint_port    = var.ocsp_endpoint_port
-
   enable_nlb_deletion_protection = module.label.stage == "production" ? true : false
+  enable_hosted_zone    = var.enable_hosted_zone
+  tags                  = module.label.tags
+
   log_filters = [
     "Accept",
     "Reject",

--- a/modules/radius/route53.tf
+++ b/modules/radius/route53.tf
@@ -1,0 +1,14 @@
+locals {
+  zone_prefixes = {
+    "development" = "dev.",
+    "pre-production" = "prep."
+  }
+}
+
+resource "aws_route53_zone" "radius" {
+  count = var.enable_hosted_zone ? 1 : 0
+
+  name = "${lookup(local.zone_prefixes, var.env, "")}nac.justice.gov.uk"
+
+  tags = var.tags
+}

--- a/modules/radius/variables.tf
+++ b/modules/radius/variables.tf
@@ -6,7 +6,6 @@ variable "short_prefix" {
   type = string
 }
 
-
 variable "vpc_id" {
   type = string
 }
@@ -65,4 +64,13 @@ variable "ocsp_endpoint_ip" {
 
 variable "ocsp_endpoint_port" {
   type = string
+}
+
+variable "enable_hosted_zone" {
+  type = bool
+  default = false
+}
+
+variable "tags" {
+  type = map(string)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -77,3 +77,8 @@ variable "enable_nac_transit_gateway_attachment" {
   type    = bool
   default = false
 }
+
+variable "enable_hosted_zone" {
+  type = bool
+  default = false
+}


### PR DESCRIPTION
The domain we want to use is nac.justice.gov.uk

This will create a zone for each environment.
Local development will not execute this.