### PR TITLE
Set radius config bucket name in the admin task definition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -136,6 +136,7 @@ module "admin" {
   secret_key_base                      = "tbc"
   radius_certificate_bucket_arn        = module.radius.s3.radius_certificate_bucket_arn
   radius_certificate_bucket_name       = module.radius.s3.radius_certificate_bucket_name
+  radius_config_bucket_name            = module.radius.s3.radius_config_bucket_name
   region                               = data.aws_region.current_region.id
   hosted_zone_id                       = var.hosted_zone_id
   hosted_zone_domain                   = var.hosted_zone_domain

--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -126,6 +126,10 @@ resource "aws_ecs_task_definition" "admin_task" {
         {
           "name": "RADIUS_SERVICE_NAME",
           "value": "${var.radius_service_name}"
+        },
+        {
+          "name": "RADIUS_CONFIG_BUCKET_NAME",
+          "value": "${var.radius_config_bucket_name}"
         }
       ],
       "image": "${aws_ecr_repository.admin_ecr.repository_url}",

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -49,6 +49,10 @@ variable "radius_certificate_bucket_name" {
   type = string
 }
 
+variable "radius_config_bucket_name" {
+  type = string
+}
+
 variable "hosted_zone_id" {
   type = string
 }

--- a/modules/radius/ecs_task_definition.tf
+++ b/modules/radius/ecs_task_definition.tf
@@ -47,7 +47,7 @@ resource "aws_ecs_task_definition" "server_task" {
       },
       {
         "name": "RADIUS_CONFIG_BUCKET_NAME",
-        "value": "${var.prefix}-config-bucket"
+        "value": "${aws_s3_bucket.config_bucket.id}"
       },
       {
         "name": "RADIUS_CERTIFICATE_BUCKET_NAME",

--- a/modules/radius/outputs.tf
+++ b/modules/radius/outputs.tf
@@ -32,5 +32,6 @@ output "s3" {
   value = {
     radius_certificate_bucket_arn  = aws_s3_bucket.certificate_bucket.arn
     radius_certificate_bucket_name = aws_s3_bucket.certificate_bucket.id
+    radius_config_bucket_name = aws_s3_bucket.config_bucket.id
   }
 }


### PR DESCRIPTION
The admin application will upload configuration files to this bucket.
Set this as an environment variable in ECS for the application to
access.