### PR TITLE
Allow the admin application to publish configurations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -137,6 +137,7 @@ module "admin" {
   radius_certificate_bucket_arn        = module.radius.s3.radius_certificate_bucket_arn
   radius_certificate_bucket_name       = module.radius.s3.radius_certificate_bucket_name
   radius_config_bucket_name            = module.radius.s3.radius_config_bucket_name
+  radius_config_bucket_arn             = module.radius.s3.radius_config_bucket_arn
   region                               = data.aws_region.current_region.id
   hosted_zone_id                       = var.hosted_zone_id
   hosted_zone_domain                   = var.hosted_zone_domain

--- a/modules/admin/iam.tf
+++ b/modules/admin/iam.tf
@@ -37,7 +37,7 @@ resource "aws_iam_role_policy" "ecs_task_policy" {
         "s3:PutObject",
         "s3:GetObject"
       ],
-      "Resource": ["${var.radius_certificate_bucket_arn}/*"]
+      "Resource": ["${var.radius_certificate_bucket_arn}/*", "${var.radius_config_bucket_arn}/*"]
     }
   ]
 }

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -53,6 +53,10 @@ variable "radius_config_bucket_name" {
   type = string
 }
 
+variable "radius_config_bucket_arn" {
+  type = string
+}
+
 variable "hosted_zone_id" {
   type = string
 }

--- a/modules/radius/outputs.tf
+++ b/modules/radius/outputs.tf
@@ -32,6 +32,7 @@ output "s3" {
   value = {
     radius_certificate_bucket_arn  = aws_s3_bucket.certificate_bucket.arn
     radius_certificate_bucket_name = aws_s3_bucket.certificate_bucket.id
+    radius_config_bucket_arn = aws_s3_bucket.config_bucket.arn
     radius_config_bucket_name = aws_s3_bucket.config_bucket.id
   }
 }


### PR DESCRIPTION
The admin ECS tasks need access to the S3 configuration bucket to
publish the authorised macs.

Allow this by modifying the IAM policy associated with ECS.