### PR TITLE
Export internal authentication service name

### DIFF
--- a/modules/radius/outputs.tf
+++ b/modules/radius/outputs.tf
@@ -11,6 +11,7 @@ output "ecs" {
     service_arn = aws_ecs_service.service.id
     service_name = aws_ecs_service.service.name
     cluster_name = aws_ecs_cluster.server_cluster.name
+    internal_service_name = aws_ecs_service.internal_service.name
   }
 }
 


### PR DESCRIPTION
Currently we only deploy the public facing authentication service
when running through the pipeline.

Publish the internal service name to parameter store so it can be
accessed to deploy the internal service as well.