### PR TITLE
Allow dynamically enabling or disabling CRL

### DIFF
--- a/modules/radius/ecs_task_definition.tf
+++ b/modules/radius/ecs_task_definition.tf
@@ -64,6 +64,10 @@ resource "aws_ecs_task_definition" "server_task" {
       {
         "name": "OCSP_URL",
         "value": "${var.ocsp_endpoint_ip}:${var.ocsp_endpoint_port}"
+      },
+      {
+        "name": "ENABLE_CRL",
+        "value": "no"
       }
     ],
     "image": "${aws_ecr_repository.docker_repository.repository_url}",


### PR DESCRIPTION
We currently enable CRL checking in production but we have no endpoint
to hit. Make this configurable and turn it off in production for now.

This sets the environment variable that FreeRadius can read to configure
the server at boot time.