### PR TITLE
Enable container insights for admin cluster

### DIFF
--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -1,6 +1,11 @@
 resource "aws_ecs_cluster" "admin_cluster" {
   name = "${var.prefix}-cluster"
 
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
   tags = var.tags
 }
 


### PR DESCRIPTION
This will show metrics for things like CPU and memory which is useful
for troubleshooting.