### PR TITLE
Add auto scaling for ECS services

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,6 +81,27 @@ module "radius" {
   }
 }
 
+module "ecs_auto_scaling_radius_public" {
+  source                                = "./modules/ecs_auto_scaling"
+  prefix                                = module.label.id
+  service_name                          = module.radius.ecs.service_name
+  cluster_name                          = module.radius.ecs.cluster_name
+}
+
+module "ecs_auto_scaling_radius_internal" {
+  source                                = "./modules/ecs_auto_scaling"
+  prefix                                = "${module.label.id}-internal"
+  service_name                          = module.radius.ecs.internal_service_name
+  cluster_name                          = module.radius.ecs.cluster_name
+}
+
+module "ecs_auto_scaling_admin" {
+  source                                = "./modules/ecs_auto_scaling"
+  prefix                                = "${module.label.id}-admin"
+  service_name                          = module.admin.ecs.service_name
+  cluster_name                          = module.admin.ecs.cluster_name
+}
+
 module "radius_vpc" {
   source                                = "./modules/vpc"
   prefix                                = module.label.id

--- a/modules/ecs_auto_scaling/main.tf
+++ b/modules/ecs_auto_scaling/main.tf
@@ -1,0 +1,95 @@
+resource "aws_appautoscaling_target" "auth_ecs_target" {
+  service_namespace  = "ecs"
+  resource_id        = "service/${var.cluster_name}/${var.service_name}"
+  max_capacity       = 10
+  min_capacity       = 2
+  scalable_dimension = "ecs:service:DesiredCount"
+}
+
+resource "aws_appautoscaling_policy" "ecs_policy_up" {
+  name               = "${var.prefix} ECS Scale Up"
+  service_namespace  = "ecs"
+  policy_type        = "StepScaling"
+  resource_id        = "service/${var.cluster_name}/${var.service_name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+
+  depends_on = [aws_appautoscaling_target.auth_ecs_target]
+}
+
+resource "aws_appautoscaling_policy" "ecs_policy_down" {
+  name               = "ECS Scale Down"
+  service_namespace  = "ecs"
+  resource_id        = "service/${var.cluster_name}/${var.service_name}"
+  policy_type        = "StepScaling"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = -1
+    }
+  }
+
+  depends_on = [aws_appautoscaling_target.auth_ecs_target]
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_cpu_alarm_high" {
+  alarm_name          = "${var.prefix}-ecs-cpu-alarm-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "70"
+
+  dimensions = {
+    ClusterName = var.cluster_name
+    ServiceName = var.service_name
+  }
+
+  alarm_description = "This alarm tells ECS to scale out based on high CPU usage"
+
+  alarm_actions = [
+    aws_appautoscaling_policy.ecs_policy_up.arn
+  ]
+
+  treat_missing_data = "breaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_cpu_alarm_low" {
+  alarm_name          = "${var.prefix}-ecs-cpu-alarm-low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "40"
+
+  dimensions = {
+    ClusterName = var.cluster_name
+    ServiceName = var.service_name
+  }
+
+  alarm_description = "This alarm tells ECS to scale in based on low CPU usage"
+
+  alarm_actions = [
+    aws_appautoscaling_policy.ecs_policy_down.arn
+  ]
+
+  treat_missing_data = "breaching"
+}

--- a/modules/ecs_auto_scaling/variables.tf
+++ b/modules/ecs_auto_scaling/variables.tf
@@ -1,0 +1,11 @@
+variable "prefix" {
+  type = string
+}
+
+variable "service_name" {
+  type = string
+}
+
+variable "cluster_name" {
+  type = string
+}


### PR DESCRIPTION
This includes:
public facing RADIUS service
internal RADIUS service
Admin portal

This will scale out when the CPU > 70% for 1 minute
Scale in when the CPU is < 40% for 1 minute

The ECS desired task count will be changed to accomodate current load.