### PR TITLE
Enable cross zone load balancing

### DIFF
--- a/modules/radius/load_balancer.tf
+++ b/modules/radius/load_balancer.tf
@@ -1,8 +1,8 @@
 resource "aws_lb" "load_balancer" {
-  name               = var.prefix
-  load_balancer_type = "network"
-  internal           = false
-  enable_cross_zone_load_balancing = false
+  name                             = var.prefix
+  load_balancer_type               = "network"
+  internal                         = false
+  enable_cross_zone_load_balancing = true
   subnet_mapping {
     subnet_id = var.public_subnets[0]
     allocation_id = aws_eip.nac_eu_west_2a.id

--- a/modules/radius/load_balancer_internal.tf
+++ b/modules/radius/load_balancer_internal.tf
@@ -1,7 +1,8 @@
 resource "aws_lb" "internal_load_balancer" {
-  name               = "${var.prefix}-private"
-  load_balancer_type = "network"
-  internal           = true
+  name                             = "${var.prefix}-private"
+  load_balancer_type               = "network"
+  internal                         = true
+  enable_cross_zone_load_balancing = true
   subnet_mapping {
     subnet_id = var.private_subnets[0]
     private_ipv4_address = var.private_ip_eu_west_2a


### PR DESCRIPTION
The load balancers are deployed to 3 AZs, containers run in 3 AZs.
Allow the load balancer to distribute the traffic across these AZs.
This improves robustness in the case of an AZ going down.