### PR TITLE
Add internal service environment variables to admin task definition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -178,6 +178,7 @@ module "admin" {
   admin_db_backup_retention_period  = var.admin_db_backup_retention_period
   radius_cluster_name               = module.radius.ecs.cluster_name
   radius_service_name               = module.radius.ecs.service_name
+  radius_internal_service_name      = module.radius.ecs.internal_service_name
   radius_service_arn                = module.radius.ecs.service_arn
   cognito_user_pool_id              = module.authentication.cognito_user_pool_id
   cognito_user_pool_domain          = module.authentication.cognito_user_pool_domain

--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -133,6 +133,10 @@ resource "aws_ecs_task_definition" "admin_task" {
           "value": "${var.radius_service_name}"
         },
         {
+          "name": "RADIUS_INTERNAL_SERVICE_NAME",
+          "value": "${var.radius_internal_service_name}"
+        },
+        {
           "name": "RADIUS_CONFIG_BUCKET_NAME",
           "value": "${var.radius_config_bucket_name}"
         },

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -101,6 +101,10 @@ variable "radius_service_name" {
   type = string
 }
 
+variable "radius_internal_service_name" {
+  type = string
+}
+
 variable "radius_service_arn" {
   type = string
 }


### PR DESCRIPTION
These values are required to deploy the internal radius cluster.
Currently only the internet facing cluster is being deployed.