### PR TITLE
Allow OCSP to be turned on or off and ability to override endpoint URL

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -22,6 +22,8 @@ env:
     TF_VAR_transit_gateway_route_table_id: "/moj-network-access-control/$ENV/transit_gateway_route_table_id"
     TF_VAR_ocsp_endpoint_ip: "/moj-network-access-control/$ENV/ocsp/endpoint_ip"
     TF_VAR_ocsp_endpoint_port: "/moj-network-access-control/$ENV/ocsp/endpoint_port"
+    TF_VAR_enable_ocsp: "/moj-network-access-control/$ENV/enable_ocsp"
+    TF_VAR_ocsp_override_cert_url: "/moj-network-access-control/$ENV/ocsp_override_cert_url"
     TF_VAR_byoip_pool_id: "/moj-network-access-control/$ENV/public_ip_pool_id"
     TF_VAR_admin_read_replica_db_username: "/moj-network-access-control/$ENV/admin_read_replica_db_username"
     TF_VAR_admin_read_replica_db_password: "/moj-network-access-control/$ENV/admin_read_replica_db_password"

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,8 @@ module "radius" {
   byoip_pool_id                  = var.byoip_pool_id
   ocsp_endpoint_ip               = var.ocsp_endpoint_ip
   ocsp_endpoint_port             = var.ocsp_endpoint_port
+  ocsp_override_cert_url         = var.ocsp_override_cert_url
+  enable_ocsp                    = var.enable_ocsp
   enable_nlb_deletion_protection = module.label.stage == "production" ? true : false
   enable_hosted_zone             = var.enable_hosted_zone
   hosted_zone_domain             = var.hosted_zone_domain

--- a/modules/radius/ecs_task_definition.tf
+++ b/modules/radius/ecs_task_definition.tf
@@ -66,6 +66,14 @@ resource "aws_ecs_task_definition" "server_task" {
         "value": "${var.ocsp_endpoint_ip}:${var.ocsp_endpoint_port}"
       },
       {
+        "name": "ENABLE_OCSP",
+        "value": "${var.enable_ocsp}"
+      },
+      {
+        "name": "OCSP_OVERRIDE_CERT_URL",
+        "value": "${var.ocsp_override_cert_url}"
+      },
+      {
         "name": "ENABLE_CRL",
         "value": "no"
       }

--- a/modules/radius/variables.tf
+++ b/modules/radius/variables.tf
@@ -98,3 +98,11 @@ variable "admin_read_replica_db_username" {
 variable "admin_read_replica_db_password" {
   type = string
 }
+
+variable "enable_ocsp" {
+  type = string
+}
+
+variable "ocsp_override_cert_url" {
+  type = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -90,3 +90,11 @@ variable "admin_read_replica_db_username" {
 variable "admin_read_replica_db_password" {
   type = string
 }
+
+variable "ocsp_override_cert_url" {
+  type = string
+}
+
+variable "enable_ocsp" {
+  type = string
+}


### PR DESCRIPTION
This allows full control of enabling OCSP, and overriding the endpoint
url.

This is required because not all environments have access to the production OCSP endpoint