### PR TITLE
Even the longest name; radius-nac-lb-preproduction is only 27 chars.

### DIFF
--- a/modules/admin/loadbalancer.tf
+++ b/modules/admin/loadbalancer.tf
@@ -1,5 +1,5 @@
 resource "aws_lb" "admin_alb" {
-  name     = "${var.short_prefix}-nac-lb"
+  name     = "nac-admin-lb-${var.short_prefix}"
   internal = false
   subnets  = var.subnet_ids
 

--- a/modules/cognito/main.tf
+++ b/modules/cognito/main.tf
@@ -4,7 +4,7 @@ locals {
 
 resource "aws_cognito_user_pool" "pool" {
   count                    = local.enabled
-  name                     = "${var.prefix}_azure_ad_pool"
+  name                     = "${var.prefix}-azure-ad-pool"
   auto_verified_attributes = ["email"]
 
   schema {
@@ -21,7 +21,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 resource "aws_cognito_user_pool_client" "client" {
   count                                = local.enabled
-  name                                 = "${var.prefix}_azure_ad_client"
+  name                                 = "${var.prefix}-azure-ad-client"
   user_pool_id                         = aws_cognito_user_pool.pool[0].id
   explicit_auth_flows                  = ["ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_CUSTOM_AUTH", "ALLOW_USER_PASSWORD_AUTH", "ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
   callback_urls                        = ["https://${var.admin_url}/users/auth/cognito/callback"]

--- a/modules/radius/load_balancer.tf
+++ b/modules/radius/load_balancer.tf
@@ -1,5 +1,5 @@
 resource "aws_lb" "load_balancer" {
-  name                             = var.prefix
+  name                             = "nac-radius-lb-${var.short_prefix}"
   load_balancer_type               = "network"
   internal                         = false
   enable_cross_zone_load_balancing = true


### PR DESCRIPTION
Changed the underscores to hyphens instead.