### PR TITLE
Create private subnets in the admin VPC

### DIFF
--- a/modules/admin_vpc/main.tf
+++ b/modules/admin_vpc/main.tf
@@ -20,6 +20,12 @@ module "vpc" {
     cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 3)
   ]
 
+  private_subnets = [
+    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 4),
+    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 5),
+    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 6)
+  ]
+
   manage_default_security_group  = true
   default_security_group_ingress = []
   default_security_group_egress  = []

--- a/modules/admin_vpc/outputs.tf
+++ b/modules/admin_vpc/outputs.tf
@@ -6,6 +6,10 @@ output "public_subnets" {
   value = module.vpc.public_subnets
 }
 
+output "private_subnets" {
+  value = module.vpc.private_subnets
+}
+
 output "public_subnet_cidr_blocks" {
   value = module.vpc.public_subnets_cidr_blocks
 }


### PR DESCRIPTION
We will move the admin database to private subnets for security.
Put in public subnets initially for debugging.