### PR TITLE
Pass private subnet ids into the admin module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -170,10 +170,8 @@ module "admin" {
   prefix                            = "${module.label.id}-admin"
   short_prefix                      = module.label.stage # avoid 32 char limit on certain resources
   tags                              = module.label.tags
-  vpc_id                            = module.admin_vpc.vpc_id
   admin_db_password                 = var.admin_db_password
   admin_db_username                 = var.admin_db_username
-  subnet_ids                        = module.admin_vpc.public_subnets
   sentry_dsn                        = var.admin_sentry_dsn
   secret_key_base                   = "tbc"
   radius_certificate_bucket_arn     = module.radius.s3.radius_certificate_bucket_arn
@@ -196,6 +194,12 @@ module "admin" {
   cognito_user_pool_client_secret   = module.authentication.cognito_user_pool_client_secret
   is_publicly_accessible            = local.publicly_accessible
   local_development_domain_affix    = var.local_development_domain_affix
+
+  vpc = {
+    id = module.admin_vpc.vpc_id
+    public_subnets = module.admin_vpc.public_subnets
+    private_subnets = module.admin_vpc.private_subnets
+  }
 
   depends_on = [
     module.admin_vpc

--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -175,7 +175,7 @@ resource "aws_ecs_service" "admin_service" {
   }
 
   network_configuration {
-    subnets = var.subnet_ids
+    subnets = var.vpc.public_subnets
 
     security_groups = [
       aws_security_group.admin_ecs.id
@@ -190,7 +190,7 @@ resource "aws_alb_target_group" "admin_tg" {
   name                 = "${var.short_prefix}-admin-nac-tg"
   port                 = "3000"
   protocol             = "HTTP"
-  vpc_id               = var.vpc_id
+  vpc_id               = var.vpc.id
   target_type          = "ip"
   deregistration_delay = 10
 

--- a/modules/admin/db.tf
+++ b/modules/admin/db.tf
@@ -35,7 +35,7 @@ resource "aws_db_instance" "admin_db" {
 
 resource "aws_db_subnet_group" "admin_db_group" {
   name       = "${var.prefix}-db-group"
-  subnet_ids = var.subnet_ids
+  subnet_ids = var.vpc.public_subnets
 
   tags = var.tags
 }

--- a/modules/admin/loadbalancer.tf
+++ b/modules/admin/loadbalancer.tf
@@ -1,7 +1,7 @@
 resource "aws_lb" "admin_alb" {
   name     = "nac-admin-lb-${var.short_prefix}"
   internal = false
-  subnets  = var.subnet_ids
+  subnets  = var.vpc.public_subnets
 
   security_groups = [
     aws_security_group.admin_alb.id

--- a/modules/admin/security_groups.tf
+++ b/modules/admin/security_groups.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "admin_alb" {
   name        = "${var.prefix}-load-balancer"
   description = "Allow Traffic to the Admin Portal"
-  vpc_id      = var.vpc_id
+  vpc_id      = var.vpc.id
 
   tags = var.tags
 
@@ -32,7 +32,7 @@ resource "aws_security_group_rule" "admin_alb_out" {
 resource "aws_security_group" "admin_db" {
   name        = "${var.prefix}-database"
   description = "Allow connections to the DB"
-  vpc_id      = var.vpc_id
+  vpc_id      = var.vpc.id
 
   lifecycle {
     create_before_destroy = true
@@ -54,7 +54,7 @@ resource "aws_security_group_rule" "admin_db_in_from_ecs" {
 resource "aws_security_group" "admin_ecs" {
   name        = "${var.prefix}-container"
   description = "Allow traffic to and from Admin ECS"
-  vpc_id      = var.vpc_id
+  vpc_id      = var.vpc.id
 
   lifecycle {
     create_before_destroy = true

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -1,16 +1,16 @@
-variable "subnet_ids" {
-  description = "List of AWS subnet IDs to place the EC2 instances and ELB into"
-  type        = list(string)
-}
-
 variable "secret_key_base" {
   type        = string
   description = "Rails secret key base variable used for the admin platform"
 }
 
-variable "vpc_id" {
-  type        = string
-  description = "VPC ID used for placing the ALB into"
+variable "vpc" {
+  type = object({
+    id = string
+    public_subnets = list(string)
+    private_subnets = list(string)
+  })
+
+  description = "Networking configuration"
 }
 
 variable "admin_db_username" {


### PR DESCRIPTION
This will be used to put the admin db in these subnets.
Refactor variables to be objects and grouped instead of individual.