### PR TITLE
Enable proxy protocol v2 on the NLB target groups

### DIFF
--- a/modules/radius/load_balancer.tf
+++ b/modules/radius/load_balancer.tf
@@ -65,6 +65,7 @@ resource "aws_lb_target_group" "target_group" {
   port                 = "1812"
   target_type          = "ip"
   deregistration_delay = 300
+  proxy_protocol_v2    = true
 
   health_check {
     port     = 8000
@@ -81,6 +82,7 @@ resource "aws_lb_target_group" "target_group_radsec" {
   port                 = "2083"
   target_type          = "ip"
   deregistration_delay = 300
+  proxy_protocol_v2    = true
 
   health_check {
     port     = 8000


### PR DESCRIPTION
This should preserve the client IP address when the request
comes into FreeRadius.