### PR TITLE
Don't restrict DNS resolution to the UK

### DIFF
--- a/modules/admin/route53.tf
+++ b/modules/admin/route53.tf
@@ -30,10 +30,6 @@ resource "aws_route53_record" "admin_app" {
   zone_id = var.hosted_zone_id
   ttl     = 3600
   type    = "CNAME"
-  set_identifier = "geolocation"
-  geolocation_routing_policy {
-    country = "GB"
-  }
 
   name    = "admin${var.local_development_domain_affix}"
   records = [aws_lb.admin_alb.dns_name]
@@ -44,11 +40,6 @@ resource "aws_route53_record" "admin_db" {
   zone_id = var.hosted_zone_id
   ttl     = 3600
   type    = "CNAME"
-  set_identifier = "geolocation"
-
-  geolocation_routing_policy {
-    country = "GB"
-  }
 
   name    = "admin-db${var.local_development_domain_affix}"
   records = [aws_db_instance.admin_db.address]


### PR DESCRIPTION
Some DNS servers are not seen as coming from the UK, fall back to the
simple routing policy