### PR TITLE
Use ID instead of ARN for replication source db

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -159,7 +159,7 @@ module "radius_vpc_flow_logs" {
 
 module "admin_read_replica" {
   source              = "./modules/admin_read_replica"
-  admin_db_arn         = module.admin.rds.admin_db_arn
+  replication_source  = module.admin.rds.admin_db_id
   subnet_ids          = module.radius_vpc.private_subnets
   rds_monitoring_role = module.admin.rds.rds_monitoring_role
   vpc_id              = module.radius_vpc.vpc_id

--- a/modules/admin/outputs.tf
+++ b/modules/admin/outputs.tf
@@ -22,6 +22,7 @@ output "ecr" {
 
 output "rds" {
   value = {
+    admin_db_id = aws_db_instance.admin_db.id
     admin_db_arn = aws_db_instance.admin_db.arn
     rds_monitoring_role = aws_iam_role.rds_monitoring_role.arn
   }

--- a/modules/admin_read_replica/radius_read_replica.tf
+++ b/modules/admin_read_replica/radius_read_replica.tf
@@ -5,7 +5,7 @@ resource "aws_db_instance" "admin_read_replica" {
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
   apply_immediately           = true
-  replicate_source_db         = var.admin_db_arn
+  replicate_source_db         = var.replication_source
   instance_class              = var.db_size
   identifier                  = var.prefix
   multi_az                    = true

--- a/modules/admin_read_replica/variables.tf
+++ b/modules/admin_read_replica/variables.tf
@@ -23,7 +23,7 @@ variable "vpc_id" {
   type = string
 }
 
-variable "admin_db_arn" {
+variable "replication_source" {
   type = string
 }
 


### PR DESCRIPTION
The read replica is not replicating properly, this is due to the
replication source being an ARN value instead of an ID.