### PR TITLE
Create the transit gateway attachment in NAC public subnets

### DIFF
--- a/modules/vpc/transit_gateway_attachment.tf
+++ b/modules/vpc/transit_gateway_attachment.tf
@@ -1,7 +1,7 @@
 resource "aws_ec2_transit_gateway_vpc_attachment" "nac_transit_gateway_attachment" {
   count = var.enable_nac_transit_gateway_attachment ? 1 : 0
 
-  subnet_ids                                      = module.vpc.private_subnets
+  subnet_ids                                      = flatten([module.vpc.private_subnets, module.vpc.public_subnets])
   transit_gateway_id                              = var.transit_gateway_id
   vpc_id                                          = module.vpc.vpc_id
   transit_gateway_default_route_table_association = false


### PR DESCRIPTION
To use the DNS servers required to resolve the OCSP endpoint, we need to
access them on the internal network.

A following commit will create the specific routes in the route tables
for the public subnets to redirect the traffic to the DNS service.