### PR TITLE
Create routes from the public subnets to the transit gateway

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,6 +18,8 @@ env:
     TF_VAR_admin_sentry_dsn: "/moj-network-access-control/$ENV/admin_sentry_dsn"
     TF_VAR_transit_gateway_id: "/moj-network-access-control/$ENV/transit_gateway_id"
     TF_VAR_transit_gateway_route_table_id: "/moj-network-access-control/$ENV/transit_gateway_route_table_id"
+    TF_VAR_mojo_dns_ip_1: "/moj-network-access-control/$ENV/mojo_dns_ip_1"
+    TF_VAR_mojo_dns_ip_2: "/moj-network-access-control/$ENV/mojo_dns_ip_2"
     TF_VAR_ocsp_endpoint_ip: "/moj-network-access-control/$ENV/ocsp/endpoint_ip"
     TF_VAR_ocsp_endpoint_port: "/moj-network-access-control/$ENV/ocsp/endpoint_port"
     TF_VAR_enable_ocsp: "/moj-network-access-control/$ENV/enable_ocsp"

--- a/main.tf
+++ b/main.tf
@@ -137,6 +137,8 @@ module "radius_vpc" {
   enable_nac_transit_gateway_attachment = var.enable_nac_transit_gateway_attachment
   transit_gateway_id                    = var.transit_gateway_id
   transit_gateway_route_table_id        = var.transit_gateway_route_table_id
+  mojo_dns_ip_1                         = var.mojo_dns_ip_1
+  mojo_dns_ip_2                         = var.mojo_dns_ip_2
   tags                                  = module.label.tags
   ocsp_endpoint_ip                      = var.ocsp_endpoint_ip
 

--- a/modules/vpc/routes.tf
+++ b/modules/vpc/routes.tf
@@ -21,3 +21,27 @@ resource "aws_route" "transit-gateway-public" {
     module.vpc
   ]
 }
+
+resource "aws_route" "transit-gateway-public-dns-server-1" {
+  for_each = var.enable_nac_transit_gateway_attachment ? toset(module.vpc.public_route_table_ids) : []
+
+  route_table_id         = each.value
+  destination_cidr_block = "${var.mojo_dns_ip_1}/32"
+  transit_gateway_id     = var.transit_gateway_id
+
+  depends_on = [
+    module.vpc
+  ]
+}
+
+resource "aws_route" "transit-gateway-public-dns-server-2" {
+  for_each = var.enable_nac_transit_gateway_attachment ? toset(module.vpc.public_route_table_ids) : []
+
+  route_table_id         = each.value
+  destination_cidr_block = "${var.mojo_dns_ip_2}/32"
+  transit_gateway_id     = var.transit_gateway_id
+
+  depends_on = [
+    module.vpc
+  ]
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -30,3 +30,11 @@ variable "transit_gateway_route_table_id" {
 variable "ocsp_endpoint_ip" {
   type = string
 }
+
+variable "mojo_dns_ip_1" {
+  type = string
+}
+
+variable "mojo_dns_ip_2" {
+  type = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -90,3 +90,11 @@ variable "eap_private_key_password" {
 variable "radsec_private_key_password" {
   type = string
 }
+
+variable "mojo_dns_ip_1" {
+  type = string
+}
+
+variable "mojo_dns_ip_2" {
+  type = string
+}


### PR DESCRIPTION
To resolve DNS queries on the MoJO DNS service, we need to route these
requests to the private IP addresses.