### PR TITLE
Use DHCP Options name servers to override the default DNS servers

### DIFF
--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -36,6 +36,8 @@ module "vpc" {
   ecr_dkr_endpoint_private_dns_enabled = true
   ecr_api_endpoint_private_dns_enabled = true
   ecr_dkr_endpoint_security_group_ids  = [aws_security_group.endpoints.id]
+  dhcp_options_netbios_name_servers    = [var.mojo_dns_ip_1, var.mojo_dns_ip_2]
+  enable_dhcp_options                  = true
 
   enable_monitoring_endpoint              = true
   monitoring_endpoint_private_dns_enabled = true


### PR DESCRIPTION
This will use the MoJO DNS servers for the entire NAC VPC.