### PR TITLE
Automate performance test config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,7 @@ apply:
 destroy:
 	aws-vault exec moj-nac-shared-services --duration=2h -- terraform destroy
 
+perf-test-setup:
+	sh ./scripts/perf_test_setup.sh                                               
+
 .PHONY: init apply destroy

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ destroy:
 perf-test-setup:
 	sh ./scripts/perf_test_setup.sh                                               
 
-.PHONY: init apply destroy
+.PHONY: init apply destroy perf-test-setup

--- a/modules/performance_testing/main.tf
+++ b/modules/performance_testing/main.tf
@@ -16,7 +16,7 @@ resource "aws_instance" "performance_testing_instance" {
   count = 10
 
   tags = {
-    Name = "MoJ Authentication Performance"
+    Name = "MoJ Authentication Performance-${count.index}"
   }
 }
 

--- a/modules/performance_testing/user_data.sh
+++ b/modules/performance_testing/user_data.sh
@@ -9,7 +9,11 @@ mkdir -p /etc/raddb/certs
 
 chmod 777 /etc/raddb/certs
 
-aws s3 sync s3://${s3_bucket_name}/ /etc/raddb/certs
+aws s3 sync s3://${s3_bucket_name}/certs/ /etc/raddb/certs
+aws s3 cp s3://${s3_bucket_name}/perf_test.sh ./
+aws s3 cp s3://${s3_bucket_name}/test.conf ./
+
+chmod 700 ./perf_test.sh
 
 cd /tmp
 rm wpa_supplicant-2.9 -fr

--- a/scripts/perf_test_setup.sh
+++ b/scripts/perf_test_setup.sh
@@ -1,0 +1,30 @@
+env=$AWS_VAULT
+
+aws s3 cp s3://mojo-$env-nac-config-bucket/clients.conf ./scripts/
+
+# Get all the IPs from EC2 
+ip_addresses=$(aws ec2 describe-instances --filters "Name=tag:Name,Values='MoJ Authentication Performance'" --query "Reservations[].Instances[].PublicIpAddress")
+trim_brackets=$(echo $ip_addresses | sed 's/^..\(.*\)..$/\1/')
+IFS='", "' read -r -a ip_array <<< $trim_brackets
+
+# For each IP append the clients conf file
+for ip in "${ip_array[@]}"
+do
+  CLIENT=$(cat <<-END
+  \n\nclient $ip/32 {\n
+  \t\tipv4addr = $ip/32\n
+  \t\tsecret = PERFTEST\n
+  \t\tshortname = perf_test_site\n}
+END
+)
+  echo $CLIENT >> ./scripts/clients.conf
+done
+
+# Upload the clients file to s3
+aws s3 cp ./scripts/clients.conf s3://mojo-$env-nac-config-bucket/clients.conf
+
+# Delete clients.conf
+rm ./scripts/clients.conf
+
+# Restart the ECS tasks
+aws ecs update-service --force-new-deployment --service mojo-$env-nac-service --cluster mojo-$env-nac-cluster


### PR DESCRIPTION
The first slice of automating the setup for performance testing:
- Copy performance test and config file when booting EC2
- Add script for adding the IP addresses of performance test EC2s to the `clients.conf` file
- Add make command