### PR TITLE
DNS Resolver and Rule

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -22,7 +22,7 @@ env:
     TF_VAR_mojo_dns_ip_2: "/moj-network-access-control/$ENV/mojo_dns_ip_2"
     TF_VAR_ocsp_endpoint_ip: "/moj-network-access-control/$ENV/ocsp/endpoint_ip"
     TF_VAR_ocsp_endpoint_port: "/moj-network-access-control/$ENV/ocsp/endpoint_port"
-    TF_VAR_ocsp_endpoint_name: "/moj-network-access-control/$ENV/ocsp/endpoint_name"
+    TF_VAR_ocsp_atos_domain: "/moj-network-access-control/$ENV/ocsp/atos/domain"
     TF_VAR_enable_ocsp: "/moj-network-access-control/$ENV/enable_ocsp"
     TF_VAR_ocsp_override_cert_url: "/moj-network-access-control/$ENV/ocsp_override_cert_url"
     TF_VAR_byoip_pool_id: "/moj-network-access-control/$ENV/public_ip_pool_id"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -22,6 +22,7 @@ env:
     TF_VAR_mojo_dns_ip_2: "/moj-network-access-control/$ENV/mojo_dns_ip_2"
     TF_VAR_ocsp_endpoint_ip: "/moj-network-access-control/$ENV/ocsp/endpoint_ip"
     TF_VAR_ocsp_endpoint_port: "/moj-network-access-control/$ENV/ocsp/endpoint_port"
+    TF_VAR_ocsp_endpoint_name: "/moj-network-access-control/$ENV/ocsp/endpoint_name"
     TF_VAR_enable_ocsp: "/moj-network-access-control/$ENV/enable_ocsp"
     TF_VAR_ocsp_override_cert_url: "/moj-network-access-control/$ENV/ocsp_override_cert_url"
     TF_VAR_byoip_pool_id: "/moj-network-access-control/$ENV/public_ip_pool_id"

--- a/main.tf
+++ b/main.tf
@@ -64,12 +64,13 @@ module "radius" {
   enable_nlb_deletion_protection = local.is_production ? true : false
   enable_hosted_zone             = var.enable_hosted_zone
   hosted_zone_domain             = var.hosted_zone_domain
-  hosted_zone_id                    = var.hosted_zone_id
+  hosted_zone_id                 = var.hosted_zone_id
   tags                           = module.label.tags
   eap_private_key_password       = var.eap_private_key_password
   radsec_private_key_password    = var.radsec_private_key_password
   mojo_dns_ip_1                  = var.mojo_dns_ip_1
   mojo_dns_ip_2                  = var.mojo_dns_ip_2
+  ocsp_endpoint_name             = var.ocsp_endpoint_name
   read_replica = {
     name = module.admin_read_replica.rds.name
     host = module.admin_read_replica.rds.host
@@ -297,3 +298,5 @@ module "performance_testing" {
     aws = aws.env
   }
 }
+
+

--- a/main.tf
+++ b/main.tf
@@ -298,5 +298,3 @@ module "performance_testing" {
     aws = aws.env
   }
 }
-
-

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ module "radius" {
   radsec_private_key_password    = var.radsec_private_key_password
   mojo_dns_ip_1                  = var.mojo_dns_ip_1
   mojo_dns_ip_2                  = var.mojo_dns_ip_2
-  ocsp_endpoint_name             = var.ocsp_endpoint_name
+  ocsp_atos_domain               = var.ocsp_atos_domain
   read_replica = {
     name = module.admin_read_replica.rds.name
     host = module.admin_read_replica.rds.host

--- a/modules/radius/route53_resolver.tf
+++ b/modules/radius/route53_resolver.tf
@@ -1,49 +1,49 @@
 resource "aws_route53_resolver_endpoint" "nac_vpc_outbound" {
-    name                = "nac-radius-resolver-${var.short_prefix}"
-    direction           = "OUTBOUND"
+  name                = "nac-radius-resolver-${var.short_prefix}"
+  direction           = "OUTBOUND"
 
-    security_group_ids  = [
-        aws_security_group.radius_server.id
-    ]
+  security_group_ids  = [
+    aws_security_group.radius_server.id
+  ]
 
-    ip_address {
-        subnet_id = var.vpc.public_subnets[0]
-    }
-    
-    ip_address {
-        subnet_id = var.vpc.public_subnets[1]
-    }
+  ip_address {
+    subnet_id = var.vpc.public_subnets[0]
+  }
 
-    ip_address {
-        subnet_id = var.vpc.public_subnets[2]
-    }
+  ip_address {
+    subnet_id = var.vpc.public_subnets[1]
+  }
 
-    ip_address {
-        subnet_id = var.vpc.private_subnets[0]
-    }
+  ip_address {
+    subnet_id = var.vpc.public_subnets[2]
+  }
 
-    ip_address {
-        subnet_id = var.vpc.private_subnets[1]
-    }
+  ip_address {
+    subnet_id = var.vpc.private_subnets[0]
+  }
 
-    ip_address {
-        subnet_id = var.vpc.private_subnets[2]
-    }
+  ip_address {
+    subnet_id = var.vpc.private_subnets[1]
+  }
+
+  ip_address {
+    subnet_id = var.vpc.private_subnets[2]
+  }
 }
 
 resource "aws_route53_resolver_rule" "nac_dns_rule" {
-    name                    = "nac-radius-resolver-rule-${var.short_prefix}"
-    rule_type               = "FORWARD"
-    domain_name             = var.ocsp_atos_domain
-    resolver_endpoint_id    = aws_route53_resolver_endpoint.nac_vpc_outbound.id
+  name                    = "nac-radius-resolver-rule-${var.short_prefix}"
+  rule_type               = "FORWARD"
+  domain_name             = var.ocsp_atos_domain
+  resolver_endpoint_id    = aws_route53_resolver_endpoint.nac_vpc_outbound.id
 
-    target_ip {
-      ip    = "${var.mojo_dns_ip_1}"
-      port  = "53"
-    }
+  target_ip {
+    ip    = "${var.mojo_dns_ip_1}"
+    port  = "53"
+  }
 
-    target_ip {
-      ip    = "${var.mojo_dns_ip_2}"
-      port  = "53"
-    }
+  target_ip {
+    ip    = "${var.mojo_dns_ip_2}"
+    port  = "53"
+  }
 }

--- a/modules/radius/route53_resolver.tf
+++ b/modules/radius/route53_resolver.tf
@@ -1,0 +1,49 @@
+resource "aws_route53_resolver_endpoint" "nac_vpc_outbound" {
+    name                = "nac-radius-resolver-${var.short_prefix}"
+    direction           = "OUTBOUND"
+
+    security_group_ids  = [
+        aws_security_group.radius_server.id
+    ]
+
+    ip_address {
+        subnet_id = var.vpc.public_subnets[0]
+    }
+    
+    ip_address {
+        subnet_id = var.vpc.public_subnets[1]
+    }
+
+    ip_address {
+        subnet_id = var.vpc.public_subnets[2]
+    }
+
+    ip_address {
+        subnet_id = var.vpc.private_subnets[0]
+    }
+
+    ip_address {
+        subnet_id = var.vpc.private_subnets[1]
+    }
+
+    ip_address {
+        subnet_id = var.vpc.private_subnets[2]
+    }
+}
+
+resource "aws_route53_resolver_rule" "nac_dns_rule" {
+    name                    = "nac-radius-resolver-rule-${var.short_prefix}"
+    rule_type               = "FORWARD"
+    domain_name             = var.ocsp_endpoint_name
+    resolver_endpoint_id    = aws_route53_resolver_endpoint.nac_vpc_outbound.id
+
+    target_ip {
+      ip    = "${var.mojo_dns_ip_1}"
+      port  = "53"
+    }
+
+    target_ip {
+      ip    = "${var.mojo_dns_ip_2}"
+      port  = "53"
+    }
+}

--- a/modules/radius/route53_resolver.tf
+++ b/modules/radius/route53_resolver.tf
@@ -34,7 +34,7 @@ resource "aws_route53_resolver_endpoint" "nac_vpc_outbound" {
 resource "aws_route53_resolver_rule" "nac_dns_rule" {
     name                    = "nac-radius-resolver-rule-${var.short_prefix}"
     rule_type               = "FORWARD"
-    domain_name             = var.ocsp_endpoint_name
+    domain_name             = var.ocsp_atos_domain
     resolver_endpoint_id    = aws_route53_resolver_endpoint.nac_vpc_outbound.id
 
     target_ip {

--- a/modules/radius/variables.tf
+++ b/modules/radius/variables.tf
@@ -96,7 +96,7 @@ variable "mojo_dns_ip_2" {
   type = string
 }
 
-variable "ocsp_endpoint_name" {
+variable "ocsp_atos_domain" {
   type = string
 }
 

--- a/modules/radius/variables.tf
+++ b/modules/radius/variables.tf
@@ -96,6 +96,10 @@ variable "mojo_dns_ip_2" {
   type = string
 }
 
+variable "ocsp_endpoint_name" {
+  type = string
+}
+
 variable "hosted_zone_id" {
   type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -98,3 +98,7 @@ variable "mojo_dns_ip_1" {
 variable "mojo_dns_ip_2" {
   type = string
 }
+
+variable "ocsp_endpoint_name" {
+  type = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -99,6 +99,6 @@ variable "mojo_dns_ip_2" {
   type = string
 }
 
-variable "ocsp_endpoint_name" {
+variable "ocsp_atos_domain" {
   type = string
 }


### PR DESCRIPTION
Resolver is outbound from our SG, and uses the 3 public/private subnets
Forward rule created, to with OCSP endpoint name from param store
Set target IPs of the forward rule to the mojo_dns_ips.