### PR TITLE
Update read replica security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -166,15 +166,16 @@ module "radius_vpc_flow_logs" {
 }
 
 module "admin_read_replica" {
-  source              = "./modules/admin_read_replica"
-  replication_source  = module.admin.rds.admin_db_arn
-  subnet_ids          = module.radius_vpc.private_subnets
-  rds_monitoring_role = module.admin.rds.rds_monitoring_role
-  vpc_id              = module.radius_vpc.vpc_id
-  db_password         = var.admin_db_password
-  db_size             = "db.t3.xlarge"
-  prefix              = "${module.label.id}-admin-read-replica"
-  tags                = module.label.tags
+  source                          = "./modules/admin_read_replica"
+  replication_source              = module.admin.rds.admin_db_arn
+  subnet_ids                      = module.radius_vpc.private_subnets
+  rds_monitoring_role             = module.admin.rds.rds_monitoring_role
+  vpc_id                          = module.radius_vpc.vpc_id
+  db_password                     = var.admin_db_password
+  db_size                         = "db.t3.xlarge"
+  radius_server_security_group_id = module.radius.ec2.radius_server_security_group_id
+  prefix                          = "${module.label.id}-admin-read-replica"
+  tags                            = module.label.tags
 
   providers = {
     aws = aws.env

--- a/modules/admin_read_replica/security_groups_read_replica.tf
+++ b/modules/admin_read_replica/security_groups_read_replica.tf
@@ -5,10 +5,10 @@ resource "aws_security_group" "admin_read_replica" {
 }
 
 resource "aws_security_group_rule" "radius_db_in" {
-  type              = "ingress"
-  from_port         = 3306
-  to_port           = 3306
-  protocol          = "tcp"
-  security_group_id = aws_security_group.admin_read_replica.id
-  cidr_blocks       = ["0.0.0.0/0"]
+  type                     = "ingress"
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.admin_read_replica.id
+  source_security_group_id = var.radius_server_security_group_id
 }

--- a/modules/admin_read_replica/variables.tf
+++ b/modules/admin_read_replica/variables.tf
@@ -30,3 +30,7 @@ variable "replication_source" {
 variable "db_size" {
   type = string
 }
+
+variable "radius_server_security_group_id" {
+  type = string
+}

--- a/modules/radius/outputs.tf
+++ b/modules/radius/outputs.tf
@@ -16,6 +16,12 @@ output "ecs" {
   }
 }
 
+output "ec2" {
+  value = {
+    radius_server_security_group_id = aws_security_group.radius_server.id
+  }
+}
+
 output "cloudwatch" {
   value = {
     server_log_group_name       = aws_cloudwatch_log_group.server_log_group.name


### PR DESCRIPTION
This was overly premissive, allowing ingress from anywhere.
Change this to only allow the radius server containers to read from it.