### PR TITLE
Update "Ignored request" Cloudwatch metric

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,7 @@ module "radius" {
   log_filters = [
     "Login OK:",
     "Login incorrect",
-    "Error: Ignoring request",
+    "Ignoring request",
     "Error: post_auth - Failed to find attribute",
     "Error: python",
     "Error:"


### PR DESCRIPTION
This string does not have "Error: " in it so this metric is being
ignored. Update this so it shows up in Grafana.