### PR TITLE
Update Radius cluster auto scaling

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -112,30 +112,22 @@ module "radius" {
 }
 
 module "ecs_auto_scaling_radius_public" {
-  source                                = "./modules/ecs_auto_scaling"
+  source                                = "./modules/ecs_auto_scaling_radius"
   prefix                                = module.label.id
   service_name                          = module.radius.ecs.service_name
   cluster_name                          = module.radius.ecs.cluster_name
+  load_balancer_arn                     = module.radius.ec2.load_balancer_arn
   providers = {
     aws = aws.env
   }
 }
 
 module "ecs_auto_scaling_radius_internal" {
-  source                                = "./modules/ecs_auto_scaling"
+  source                                = "./modules/ecs_auto_scaling_radius"
   prefix                                = "${module.label.id}-internal"
   service_name                          = module.radius.ecs.internal_service_name
   cluster_name                          = module.radius.ecs.cluster_name
-  providers = {
-    aws = aws.env
-  }
-}
-
-module "ecs_auto_scaling_admin" {
-  source                                = "./modules/ecs_auto_scaling"
-  prefix                                = "${module.label.id}-admin"
-  service_name                          = module.admin.ecs.service_name
-  cluster_name                          = module.admin.ecs.cluster_name
+  load_balancer_arn                     = module.radius.ec2.internal_load_balancer_arn
   providers = {
     aws = aws.env
   }

--- a/modules/admin/auto_scaling.tf
+++ b/modules/admin/auto_scaling.tf
@@ -1,6 +1,6 @@
 resource "aws_appautoscaling_target" "auth_ecs_target" {
   service_namespace  = "ecs"
-  resource_id        = "service/${var.cluster_name}/${var.service_name}"
+  resource_id        = "service/${aws_ecs_cluster.admin_cluster.name}/${aws_ecs_service.admin_service.name}"
   max_capacity       = 21
   min_capacity       = 3
   scalable_dimension = "ecs:service:DesiredCount"
@@ -10,7 +10,7 @@ resource "aws_appautoscaling_policy" "ecs_policy_up" {
   name               = "${var.prefix} ECS Scale Up"
   service_namespace  = "ecs"
   policy_type        = "StepScaling"
-  resource_id        = "service/${var.cluster_name}/${var.service_name}"
+  resource_id        = "service/${aws_ecs_cluster.admin_cluster.name}/${aws_ecs_service.admin_service.name}"
   scalable_dimension = "ecs:service:DesiredCount"
 
   step_scaling_policy_configuration {
@@ -29,7 +29,7 @@ resource "aws_appautoscaling_policy" "ecs_policy_up" {
 resource "aws_appautoscaling_policy" "ecs_policy_down" {
   name               = "ECS Scale Down"
   service_namespace  = "ecs"
-  resource_id        = "service/${var.cluster_name}/${var.service_name}"
+  resource_id        = "service/${aws_ecs_cluster.admin_cluster.name}/${aws_ecs_service.admin_service.name}"
   policy_type        = "StepScaling"
   scalable_dimension = "ecs:service:DesiredCount"
 
@@ -57,8 +57,8 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpu_alarm_high" {
   threshold           = "15"
 
   dimensions = {
-    ClusterName = var.cluster_name
-    ServiceName = var.service_name
+    ClusterName = aws_ecs_cluster.admin_cluster.name
+    ServiceName = aws_ecs_service.admin_service.name
   }
 
   alarm_description = "This alarm tells ECS to scale out based on high CPU usage"
@@ -81,8 +81,8 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpu_alarm_low" {
   threshold           = "40"
 
   dimensions = {
-    ClusterName = var.cluster_name
-    ServiceName = var.service_name
+    ClusterName = aws_ecs_cluster.admin_cluster.name
+    ServiceName = aws_ecs_service.admin_service.name
   }
 
   alarm_description = "This alarm tells ECS to scale in based on low CPU usage"

--- a/modules/ecs_auto_scaling_radius/main.tf
+++ b/modules/ecs_auto_scaling_radius/main.tf
@@ -1,0 +1,94 @@
+resource "aws_appautoscaling_target" "auth_ecs_target" {
+  service_namespace  = "ecs"
+  resource_id        = "service/${var.cluster_name}/${var.service_name}"
+  max_capacity       = 21
+  min_capacity       = 3
+  scalable_dimension = "ecs:service:DesiredCount"
+}
+
+resource "aws_appautoscaling_policy" "ecs_policy_up" {
+  name               = "${var.prefix} ECS Scale Up"
+  service_namespace  = "ecs"
+  policy_type        = "StepScaling"
+  resource_id        = "service/${var.cluster_name}/${var.service_name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+
+  depends_on = [aws_appautoscaling_target.auth_ecs_target]
+}
+
+resource "aws_appautoscaling_policy" "ecs_policy_down" {
+  name               = "ECS Scale Down"
+  service_namespace  = "ecs"
+  resource_id        = "service/${var.cluster_name}/${var.service_name}"
+  policy_type        = "StepScaling"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = -1
+    }
+  }
+
+  depends_on = [aws_appautoscaling_target.auth_ecs_target]
+}
+
+resource "aws_cloudwatch_metric_alarm" "packets_high" {
+  alarm_name                = "nacs-packets-per-container-high"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "2"
+  threshold                 = "60"
+  alarm_description         = "Packets processed per container"
+  insufficient_data_actions = []
+
+  metric_query {
+    id          = "e1"
+    expression  = "m1/m2"
+    label       = "Packet count per container"
+    return_data = "true"
+  }
+
+  metric_query {
+    id = "m1"
+
+    metric {
+      metric_name = "ProcessedPackets"
+      namespace   = "AWS/NetworkELB"
+      period      = "60"
+      stat        = "Sum"
+
+      dimensions = {
+        LoadBalancer = var.load_balancer_arn
+      }
+    }
+  }
+
+  metric_query {
+    id = "m2"
+
+    metric {
+      metric_name = "CPUUtilization"
+      namespace   = "AWS/ECS"
+      period      = "60"
+      stat        = "SampleCount"
+
+      dimensions = {
+        ClusterName = var.cluster_name
+        ServiceName = var.service_name
+      }
+    }
+  }
+}

--- a/modules/ecs_auto_scaling_radius/variables.tf
+++ b/modules/ecs_auto_scaling_radius/variables.tf
@@ -9,3 +9,7 @@ variable "service_name" {
 variable "cluster_name" {
   type = string
 }
+
+variable "load_balancer_arn" {
+  type = string
+}

--- a/modules/radius/outputs.tf
+++ b/modules/radius/outputs.tf
@@ -20,6 +20,8 @@ output "ecs" {
 output "ec2" {
   value = {
     radius_server_security_group_id = aws_security_group.radius_server.id
+    load_balancer_arn = aws_lb.load_balancer.arn
+    internal_load_balancer_arn = aws_lb.internal_load_balancer.arn
   }
 }
 


### PR DESCRIPTION
Instead of monitoring CPU and memory of the cluster, which doesn't
correlate directly with the amount of work that FreeRadius is doing,
look at the number of packets processed per container instead.

This gives us fine grained control over how much traffic/authentications we'd
like each container to process.

Currently set to 60 packets per container to test this scaling event, an
investigation needs to be done to find out what this number will be on
the production service. TBC during performance testing.