### PR TITLE
Re-instate geo-location routing policy for admin CNAME

### DIFF
--- a/modules/admin/route53.tf
+++ b/modules/admin/route53.tf
@@ -30,6 +30,10 @@ resource "aws_route53_record" "admin_app" {
   zone_id = var.hosted_zone_id
   ttl     = 3600
   type    = "CNAME"
+  set_identifier = "geolocation"
+  geolocation_routing_policy {
+    country = "GB"
+  }
 
   name    = "admin${var.local_development_domain_affix}"
   records = [aws_lb.admin_alb.dns_name]


### PR DESCRIPTION
This was suspected to have caused issues with intermittent DNS
resolution of the admin portal. The cause was found to be missing
hosted zones in the parent AWS account.

We want to restrict admin URL resolution to the UK. Remains to be seen
if this reduces the number of unauthorised login attempts. We don't
expect administrators to be configuring NACS from outside the UK.