### PR TITLE
Ignore desired count when applying

### DIFF
--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -215,6 +215,10 @@ resource "aws_ecs_service" "admin_service" {
 
     assign_public_ip = true
   }
+
+  lifecycle {
+    ignore_changes = ["desired_count"]
+  }
 }
 
 resource "aws_alb_target_group" "admin_tg" {

--- a/modules/radius/ecs.tf
+++ b/modules/radius/ecs.tf
@@ -5,7 +5,7 @@ resource "aws_ecs_cluster" "server_cluster" {
     name  = "containerInsights"
     value = "enabled"
   }
-  
+
   tags = var.tags
 }
 
@@ -41,6 +41,10 @@ resource "aws_ecs_service" "service" {
 
     assign_public_ip = true
   }
+
+  lifecycle {
+    ignore_changes = ["desired_count"]
+  }
 }
 
 resource "aws_ecs_service" "internal_service" {
@@ -73,5 +77,8 @@ resource "aws_ecs_service" "internal_service" {
     ]
 
     assign_public_ip = false
+  }
+  lifecycle {
+    ignore_changes = ["desired_count"]
   }
 }


### PR DESCRIPTION
If a cluster (Radius or admin) has scaled due to load, we don't want to
reset that count by running terraform through the build pipelines.