### PR TITLE
Update AWS resource tags to conform to MoJ best practices

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,9 +32,9 @@ module "label" {
   name      = var.service_name
 
   tags = {
-    "business-unit"    = "MoJO"
-    "application"      = "nac",
-    "is-production"    = "true"
+    "business-unit"    = "HQ"
+    "application"      = "network-access-control"
+    "is-production"    = tostring(local.is_production)
     "owner"            = "nac@digital.justice.gov.uk"
     "environment-name" = "global"
     "source-code"      = "https://github.com/ministryofjustice/network-access-control-infrastructure"


### PR DESCRIPTION
As recommended here: https://github.com/ministryofjustice/staff#tags-for-application-and-services