### PR TITLE
Move Admin service into the NACS ECS cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -198,6 +198,7 @@ module "admin" {
   hosted_zone_id                    = var.hosted_zone_id
   hosted_zone_domain                = var.hosted_zone_domain
   radius_cluster_name               = module.radius.ecs.cluster_name
+  radius_cluster_id                 = module.radius.ecs.cluster_id
   radius_service_name               = module.radius.ecs.service_name
   radius_internal_service_name      = module.radius.ecs.internal_service_name
   radius_service_arn                = module.radius.ecs.service_arn

--- a/modules/admin/auto_scaling.tf
+++ b/modules/admin/auto_scaling.tf
@@ -1,6 +1,6 @@
 resource "aws_appautoscaling_target" "auth_ecs_target" {
   service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_cluster.admin_cluster.name}/${aws_ecs_service.admin_service.name}"
+  resource_id        = "service/${var.radius_cluster_name}/${aws_ecs_service.admin_service.name}"
   max_capacity       = 21
   min_capacity       = 3
   scalable_dimension = "ecs:service:DesiredCount"
@@ -10,7 +10,7 @@ resource "aws_appautoscaling_policy" "ecs_policy_up" {
   name               = "${var.prefix} ECS Scale Up"
   service_namespace  = "ecs"
   policy_type        = "StepScaling"
-  resource_id        = "service/${aws_ecs_cluster.admin_cluster.name}/${aws_ecs_service.admin_service.name}"
+  resource_id        = "service/${var.radius_cluster_name}/${aws_ecs_service.admin_service.name}"
   scalable_dimension = "ecs:service:DesiredCount"
 
   step_scaling_policy_configuration {
@@ -29,7 +29,7 @@ resource "aws_appautoscaling_policy" "ecs_policy_up" {
 resource "aws_appautoscaling_policy" "ecs_policy_down" {
   name               = "ECS Scale Down"
   service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_cluster.admin_cluster.name}/${aws_ecs_service.admin_service.name}"
+  resource_id        = "service/${var.radius_cluster_name}/${aws_ecs_service.admin_service.name}"
   policy_type        = "StepScaling"
   scalable_dimension = "ecs:service:DesiredCount"
 
@@ -57,7 +57,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpu_alarm_high" {
   threshold           = "15"
 
   dimensions = {
-    ClusterName = aws_ecs_cluster.admin_cluster.name
+    ClusterName = var.radius_cluster_name
     ServiceName = aws_ecs_service.admin_service.name
   }
 
@@ -83,7 +83,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpu_alarm_low" {
   threshold           = "40"
 
   dimensions = {
-    ClusterName = aws_ecs_cluster.admin_cluster.name
+    ClusterName = var.radius_cluster_name
     ServiceName = aws_ecs_service.admin_service.name
   }
 

--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -1,14 +1,3 @@
-resource "aws_ecs_cluster" "admin_cluster" {
-  name = "${var.prefix}-cluster"
-
-  setting {
-    name  = "containerInsights"
-    value = "enabled"
-  }
-
-  tags = var.tags
-}
-
 resource "aws_cloudwatch_log_group" "admin_log_group" {
   name = "${var.prefix}-log-group"
 
@@ -197,7 +186,7 @@ EOF
 resource "aws_ecs_service" "admin_service" {
   depends_on      = [aws_alb_listener.alb_listener]
   name            = var.prefix
-  cluster         = aws_ecs_cluster.admin_cluster.id
+  cluster         = var.radius_cluster_id
   task_definition = aws_ecs_task_definition.admin_task.arn
   desired_count   = 3
   launch_type     = "FARGATE"

--- a/modules/admin/outputs.tf
+++ b/modules/admin/outputs.tf
@@ -8,7 +8,7 @@ output "admin_url" {
 
 output "ecs" {
   value = {
-    cluster_name = aws_ecs_cluster.admin_cluster.name
+    cluster_name = var.radius_cluster_name
     service_name = aws_ecs_service.admin_service.name
     task_definition_name = aws_ecs_task_definition.admin_task.id
   }

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -101,6 +101,10 @@ variable "radius_cluster_name" {
   type = string
 }
 
+variable "radius_cluster_id" {
+  type = string
+}
+
 variable "radius_service_name" {
   type = string
 }

--- a/modules/radius/outputs.tf
+++ b/modules/radius/outputs.tf
@@ -11,6 +11,7 @@ output "ecs" {
     service_arn = aws_ecs_service.service.id
     service_name = aws_ecs_service.service.name
     cluster_name = aws_ecs_cluster.server_cluster.name
+    cluster_id = aws_ecs_cluster.server_cluster.id
     task_definition_name = aws_ecs_task_definition.server_task.id
     internal_service_name = aws_ecs_service.internal_service.name
     internal_service_arn = aws_ecs_service.internal_service.id


### PR DESCRIPTION
Cluster is a logical grouping of services and it doesn't make sense to
split the admin and radius service into separate clusters.