### PR TITLE
Improve naming of NACS services in ECS cluster

### DIFF
--- a/modules/admin/ecs.tf
+++ b/modules/admin/ecs.tf
@@ -185,7 +185,7 @@ EOF
 
 resource "aws_ecs_service" "admin_service" {
   depends_on      = [aws_alb_listener.alb_listener]
-  name            = var.prefix
+  name            = "admin"
   cluster         = var.radius_cluster_id
   task_definition = aws_ecs_task_definition.admin_task.arn
   desired_count   = 3

--- a/modules/radius/ecs.tf
+++ b/modules/radius/ecs.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_cluster" "server_cluster" {
 }
 
 resource "aws_ecs_service" "service" {
-  name            = "${var.prefix}-service"
+  name            = "public"
   cluster         = aws_ecs_cluster.server_cluster.id
   task_definition = aws_ecs_task_definition.server_task.arn
   desired_count   = 3
@@ -50,7 +50,7 @@ resource "aws_ecs_service" "service" {
 }
 
 resource "aws_ecs_service" "internal_service" {
-  name            = "${var.prefix}-internal-service"
+  name            = "internal"
   cluster         = aws_ecs_cluster.server_cluster.id
   task_definition = aws_ecs_task_definition.server_task.arn
   desired_count   = 3


### PR DESCRIPTION
These don't have to be globally unique identifiers and are namespaced by
cluster. Use less verbose names.