### PR TITLE
Allow planning production infrastructure changes

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -50,6 +50,11 @@ phases:
       - terraform init -no-color --backend-config="key=terraform.$ENV.state"
       - terraform workspace new $ENV || true
       - terraform workspace select $ENV
-      - terraform apply --auto-approve -no-color
-      - ./scripts/publish_terraform_outputs.sh
-      - ./scripts/route53/ensure_delegated_non_production_subdomains.sh
+      - |
+         if [[ "${PLAN}" == "true" ]]; then
+            terraform plan
+         else
+            terraform apply --auto-approve -no-color
+            ./scripts/publish_terraform_outputs.sh
+            ./scripts/route53/ensure_delegated_non_production_subdomains.sh
+         fi


### PR DESCRIPTION
This will output `terraform plan` before reaching the manual approval
stage. This change can then be accepted or rejected before being applied
to production infrastructure.