### PR TITLE
Fix Terraform deprecation warnings

### DIFF
--- a/modules/admin/ecs.tf
+++ b/modules/admin/ecs.tf
@@ -208,7 +208,9 @@ resource "aws_ecs_service" "admin_service" {
   }
 
   lifecycle {
-    ignore_changes = ["desired_count"]
+    ignore_changes = [
+      desired_count
+    ]
   }
 
   tags = var.tags

--- a/modules/radius/ecs.tf
+++ b/modules/radius/ecs.tf
@@ -43,7 +43,9 @@ resource "aws_ecs_service" "service" {
   }
 
   lifecycle {
-    ignore_changes = ["desired_count"]
+    ignore_changes = [
+      desired_count
+    ]
   }
 
   tags = var.tags
@@ -81,7 +83,9 @@ resource "aws_ecs_service" "internal_service" {
     assign_public_ip = false
   }
   lifecycle {
-    ignore_changes = ["desired_count"]
+    ignore_changes = [
+      desired_count
+    ]
   }
 
   tags = var.tags


### PR DESCRIPTION
Latest version of Terraform does not require that resources be quoted as
strings.