### PR TITLE
Silence required provider warning message

### DIFF
--- a/modules/admin/required_providers.tf
+++ b/modules/admin/required_providers.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_providers {
+    aws = {
+    }
+  }
+}

--- a/modules/admin_read_replica/required_providers.tf
+++ b/modules/admin_read_replica/required_providers.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_providers {
+    aws = {
+    }
+  }
+}

--- a/modules/admin_vpc/required_providers.tf
+++ b/modules/admin_vpc/required_providers.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_providers {
+    aws = {
+    }
+  }
+}

--- a/modules/cognito/required_providers.tf
+++ b/modules/cognito/required_providers.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_providers {
+    aws = {
+    }
+  }
+}

--- a/modules/ecs_auto_scaling_radius/required_providers.tf
+++ b/modules/ecs_auto_scaling_radius/required_providers.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_providers {
+    aws = {
+    }
+  }
+}

--- a/modules/performance_testing/required_providers.tf
+++ b/modules/performance_testing/required_providers.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_providers {
+    aws = {
+    }
+  }
+}

--- a/modules/radius/required_providers.tf
+++ b/modules/radius/required_providers.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_providers {
+    aws = {
+    }
+  }
+}

--- a/modules/vpc/required_providers.tf
+++ b/modules/vpc/required_providers.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_providers {
+    aws = {
+    }
+  }
+}

--- a/modules/vpc_flow_logs/required_providers.tf
+++ b/modules/vpc_flow_logs/required_providers.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_providers {
+    aws = {
+    }
+  }
+}


### PR DESCRIPTION
In the new versions of Terraform, required_providers have to be
explicity defined in the module using it.

Currently we get the following message whenever applying:

`Warning: Provider aws is undefined

  on main.tf line 110, in module "radius":
 110:     aws = aws.env

Module module.radius does **t declare a provider named aws.
If you wish to specify a provider configuration for the module, add an entry
for aws in the required_providers block within the module.

(and 10 more similar warnings elsewhere)`

Fix this by adding required_providers to each module.