### PR TITLE
Re-enable performance testing module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -286,7 +286,7 @@ module "admin_vpc_flow_logs" {
 
 module "performance_testing" {
   source = "./modules/performance_testing"
-  count = local.is_development ? 0 : 0
+  count = local.is_development ? 1 : 0
   prefix = "${module.label.id}-perf"
   vpc_id = module.radius_vpc.vpc_id
   subnets = module.radius_vpc.public_subnets

--- a/modules/performance_testing/main.tf
+++ b/modules/performance_testing/main.tf
@@ -1,7 +1,7 @@
 resource "aws_instance" "performance_testing_instance" {
   ami           = "ami-07438ed9014cde68f"
   instance_type = "t4g.medium"
-  count         = 0
+  count         = 1
 
   vpc_security_group_ids = [
     aws_security_group.performance_testing_instance.id


### PR DESCRIPTION
This will force some metrics to be published to the Grafana dashboards