### PR TITLE
Change login incorrect metric

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ module "radius" {
 
   log_filters = [
     "Sent Access-Accept",
-    "Login incorrect",
+    "Sent Access-Reject",
     "Ignoring request to auth proto tcp address",
     "Ignoring request to auth address",
     "Error: post_auth - Failed to find attribute",


### PR DESCRIPTION
We will use the FreeRadius Access-Accept and Access-Reject metrics
instead of the freeradius logging module with "Login OK" and "Login
incorrect", these fire off more than once and will result in double
numbers of successful and unsuccessful authentications.