### PR TITLE
Output background worker service name

### DIFF
--- a/modules/admin/outputs.tf
+++ b/modules/admin/outputs.tf
@@ -10,6 +10,7 @@ output "ecs" {
   value = {
     cluster_name = var.radius_cluster_name
     service_name = aws_ecs_service.admin_service.name
+    background_worker_service_name = aws_ecs_service.admin_background_worker_service.name
     task_definition_name = aws_ecs_task_definition.admin_task.id
   }
 }


### PR DESCRIPTION
This is required to deploy during a release in the build pipelines.