### PR TITLE
Overwrite the Name tag on the admin VPC

### DIFF
--- a/modules/admin_vpc/main.tf
+++ b/modules/admin_vpc/main.tf
@@ -30,5 +30,5 @@ module "vpc" {
   default_security_group_ingress = []
   default_security_group_egress  = []
 
-  tags = var.tags
+  tags = merge(var.tags, {"Name"=var.prefix})
 }


### PR DESCRIPTION
Even though a name is supplied to the VPC resource, the Name tag takes
precedence. Currently both VPCs (radius and admin) have exactly the same
name, making it difficult to distinguish between.

Overwrite the name tag with the correct name sent to the module.