### PR TITLE
Send logs to temporary log group

### DIFF
--- a/modules/radius/ecs.tf
+++ b/modules/radius/ecs.tf
@@ -29,11 +29,11 @@ resource "aws_ecs_service" "service" {
   }
 
   network_configuration {
-      subnets = [
-        var.vpc.public_subnets[0],
-        var.vpc.public_subnets[1],
-        var.vpc.public_subnets[2]
-      ]
+    subnets = [
+      var.vpc.public_subnets[0],
+      var.vpc.public_subnets[1],
+      var.vpc.public_subnets[2]
+    ]
 
     security_groups = [
       aws_security_group.radius_server.id
@@ -74,7 +74,7 @@ resource "aws_ecs_service" "internal_service" {
     subnets = [
       var.vpc.private_subnets[0],
       var.vpc.private_subnets[1]
-      ]
+    ]
 
     security_groups = [
       aws_security_group.radius_server.id

--- a/modules/radius/ecs_task_definition.tf
+++ b/modules/radius/ecs_task_definition.tf
@@ -113,7 +113,7 @@ resource "aws_ecs_task_definition" "server_task" {
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
-        "awslogs-group": "${aws_cloudwatch_log_group.server_log_group.name}",
+        "awslogs-group": "${aws_cloudwatch_log_group.server_performance_log_group.name}",
         "awslogs-region": "eu-west-2",
         "awslogs-stream-prefix": "eu-west-2-docker-logs"
       }

--- a/modules/radius/iam.tf
+++ b/modules/radius/iam.tf
@@ -7,7 +7,7 @@ resource "aws_iam_role" "ecs_task_role" {
 }
 
 resource "aws_iam_role" "ecs_execution_role" {
-  name               = "${var.prefix}-ecs-execution-role"
+  name = "${var.prefix}-ecs-execution-role"
 
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 

--- a/modules/radius/load_balancer.tf
+++ b/modules/radius/load_balancer.tf
@@ -9,17 +9,17 @@ resource "aws_lb" "load_balancer" {
   }
 
   subnet_mapping {
-    subnet_id = var.vpc.public_subnets[0]
+    subnet_id     = var.vpc.public_subnets[0]
     allocation_id = aws_eip.nac_eu_west_2a.id
   }
 
   subnet_mapping {
-    subnet_id = var.vpc.public_subnets[1]
+    subnet_id     = var.vpc.public_subnets[1]
     allocation_id = aws_eip.nac_eu_west_2b.id
   }
 
   subnet_mapping {
-    subnet_id = var.vpc.public_subnets[2]
+    subnet_id     = var.vpc.public_subnets[2]
     allocation_id = aws_eip.nac_eu_west_2c.id
   }
 
@@ -31,19 +31,19 @@ resource "aws_lb" "load_balancer" {
 resource "aws_eip" "nac_eu_west_2a" {
   vpc              = true
   public_ipv4_pool = var.byoip_pool_id
-  tags = var.tags
+  tags             = var.tags
 }
 
 resource "aws_eip" "nac_eu_west_2b" {
   vpc              = true
   public_ipv4_pool = var.byoip_pool_id
-  tags = var.tags
+  tags             = var.tags
 }
 
 resource "aws_eip" "nac_eu_west_2c" {
   vpc              = true
   public_ipv4_pool = var.byoip_pool_id
-  tags = var.tags
+  tags             = var.tags
 }
 
 resource "aws_lb_listener" "udp" {
@@ -121,7 +121,7 @@ resource "aws_s3_bucket" "lb_log_bucket" {
     id      = "30_day_retention_lb_bucket_logs"
     enabled = true
     expiration {
-        days = 30
+      days = 30
     }
   }
 

--- a/modules/radius/load_balancer_internal.tf
+++ b/modules/radius/load_balancer_internal.tf
@@ -4,17 +4,17 @@ resource "aws_lb" "internal_load_balancer" {
   internal                         = true
   enable_cross_zone_load_balancing = true
   subnet_mapping {
-    subnet_id = var.vpc.private_subnets[0]
+    subnet_id            = var.vpc.private_subnets[0]
     private_ipv4_address = var.vpc.private_ip_eu_west_2a
   }
 
   subnet_mapping {
-    subnet_id = var.vpc.private_subnets[1]
+    subnet_id            = var.vpc.private_subnets[1]
     private_ipv4_address = var.vpc.private_ip_eu_west_2b
   }
 
   subnet_mapping {
-    subnet_id = var.vpc.private_subnets[2]
+    subnet_id            = var.vpc.private_subnets[2]
     private_ipv4_address = var.vpc.private_ip_eu_west_2c
   }
 

--- a/modules/radius/log_metrics.tf
+++ b/modules/radius/log_metrics.tf
@@ -3,7 +3,7 @@ resource "aws_cloudwatch_log_metric_filter" "radius_request_filter" {
 
   name           = replace(each.value, ":", "")
   pattern        = format("\"%s\"", each.value)
-  log_group_name = aws_cloudwatch_log_group.server_log_group.name
+  log_group_name = aws_cloudwatch_log_group.server_performance_log_group.name
 
   metric_transformation {
     name          = replace(each.value, ":", "")

--- a/modules/radius/logging.tf
+++ b/modules/radius/logging.tf
@@ -6,6 +6,14 @@ resource "aws_cloudwatch_log_group" "server_log_group" {
   tags = var.tags
 }
 
+resource "aws_cloudwatch_log_group" "server_performance_log_group" {
+  name = "${var.prefix}-server-performance-log-group"
+
+  retention_in_days = 1
+
+  tags = var.tags
+}
+
 resource "aws_cloudwatch_log_group" "server_nginx_log_group" {
   name = "${var.prefix}-server-nginx-log-group"
 

--- a/modules/radius/outputs.tf
+++ b/modules/radius/outputs.tf
@@ -8,20 +8,20 @@ output "ecr" {
 
 output "ecs" {
   value = {
-    service_arn = aws_ecs_service.service.id
-    service_name = aws_ecs_service.service.name
-    cluster_name = aws_ecs_cluster.server_cluster.name
-    cluster_id = aws_ecs_cluster.server_cluster.id
-    task_definition_name = aws_ecs_task_definition.server_task.id
+    service_arn           = aws_ecs_service.service.id
+    service_name          = aws_ecs_service.service.name
+    cluster_name          = aws_ecs_cluster.server_cluster.name
+    cluster_id            = aws_ecs_cluster.server_cluster.id
+    task_definition_name  = aws_ecs_task_definition.server_task.id
     internal_service_name = aws_ecs_service.internal_service.name
-    internal_service_arn = aws_ecs_service.internal_service.id
+    internal_service_arn  = aws_ecs_service.internal_service.id
   }
 }
 
 output "ec2" {
   value = {
-    radius_server_security_group_id = aws_security_group.radius_server.id
-    load_balancer_arn_suffix = aws_lb.load_balancer.arn_suffix
+    radius_server_security_group_id   = aws_security_group.radius_server.id
+    load_balancer_arn_suffix          = aws_lb.load_balancer.arn_suffix
     internal_load_balancer_arn_suffix = aws_lb.internal_load_balancer.arn_suffix
   }
 }
@@ -42,11 +42,11 @@ output "iam" {
 
 output "s3" {
   value = {
-    radius_certificate_bucket_arn  = aws_s3_bucket.certificate_bucket.arn
-    radius_certificate_bucket_name = aws_s3_bucket.certificate_bucket.id
-    radius_config_bucket_arn = aws_s3_bucket.config_bucket.arn
-    radius_config_bucket_name = aws_s3_bucket.config_bucket.id
-    radius_config_bucket_key_arn = aws_kms_key.config_bucket_key.arn
+    radius_certificate_bucket_arn     = aws_s3_bucket.certificate_bucket.arn
+    radius_certificate_bucket_name    = aws_s3_bucket.certificate_bucket.id
+    radius_config_bucket_arn          = aws_s3_bucket.config_bucket.arn
+    radius_config_bucket_name         = aws_s3_bucket.config_bucket.id
+    radius_config_bucket_key_arn      = aws_kms_key.config_bucket_key.arn
     radius_certificate_bucket_key_arn = aws_kms_key.certificate_bucket_key.arn
   }
 }

--- a/modules/radius/route53.tf
+++ b/modules/radius/route53.tf
@@ -1,6 +1,6 @@
 locals {
   zone_prefixes = {
-    "development" = "dev.",
+    "development"    = "dev.",
     "pre-production" = "prep."
   }
 }

--- a/modules/radius/route53_radsec.tf
+++ b/modules/radius/route53_radsec.tf
@@ -1,8 +1,8 @@
 resource "aws_route53_record" "radsec" {
-  zone_id = var.hosted_zone_id
-  ttl     = 3600
-  type    = "CNAME"
-  name    = "radsec${var.local_development_domain_affix}"
-  records = [aws_lb.load_balancer.dns_name]
+  zone_id         = var.hosted_zone_id
+  ttl             = 3600
+  type            = "CNAME"
+  name            = "radsec${var.local_development_domain_affix}"
+  records         = [aws_lb.load_balancer.dns_name]
   allow_overwrite = true
 }

--- a/modules/radius/route53_resolver.tf
+++ b/modules/radius/route53_resolver.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_resolver_endpoint" "nac_vpc_outbound" {
-  count               = var.enable_ocsp_dns_resolver ? 1 : 0
+  count = var.enable_ocsp_dns_resolver ? 1 : 0
 
-  name                = "nac-radius-resolver-${var.short_prefix}"
-  direction           = "OUTBOUND"
+  name      = "nac-radius-resolver-${var.short_prefix}"
+  direction = "OUTBOUND"
 
-  security_group_ids  = [
+  security_group_ids = [
     aws_security_group.radius_server.id
   ]
 
@@ -20,28 +20,28 @@ resource "aws_route53_resolver_endpoint" "nac_vpc_outbound" {
 }
 
 resource "aws_route53_resolver_rule" "nac_dns_rule" {
-  count                   = var.enable_ocsp_dns_resolver ? 1 : 0
+  count = var.enable_ocsp_dns_resolver ? 1 : 0
 
-  name                    = "nac-radius-resolver-rule-${var.short_prefix}"
-  rule_type               = "FORWARD"
-  domain_name             = var.ocsp_atos_domain
-  resolver_endpoint_id    = aws_route53_resolver_endpoint.nac_vpc_outbound.*.id[0]
+  name                 = "nac-radius-resolver-rule-${var.short_prefix}"
+  rule_type            = "FORWARD"
+  domain_name          = var.ocsp_atos_domain
+  resolver_endpoint_id = aws_route53_resolver_endpoint.nac_vpc_outbound.*.id[0]
 
   target_ip {
-    ip    = "${var.mojo_dns_ip_1}"
-    port  = "53"
+    ip   = var.mojo_dns_ip_1
+    port = "53"
   }
 
   target_ip {
-    ip    = "${var.mojo_dns_ip_2}"
-    port  = "53"
+    ip   = var.mojo_dns_ip_2
+    port = "53"
   }
 
   tags = var.tags
 }
 
 resource "aws_route53_resolver_rule_association" "nac_dns_rule_association" {
-  count            = var.enable_ocsp_dns_resolver ? 1 : 0
+  count = var.enable_ocsp_dns_resolver ? 1 : 0
 
   resolver_rule_id = aws_route53_resolver_rule.nac_dns_rule.*.id[0]
   vpc_id           = var.vpc.id

--- a/modules/radius/s3.tf
+++ b/modules/radius/s3.tf
@@ -25,7 +25,7 @@ data "template_file" "config_bucket_policy" {
   template = file("${path.module}/policies/bucket_policy.json")
 
   vars = {
-    bucket_arn = aws_s3_bucket.config_bucket.arn,
+    bucket_arn        = aws_s3_bucket.config_bucket.arn,
     ecs_task_role_arn = aws_iam_role.ecs_task_role.arn
   }
 }
@@ -60,7 +60,7 @@ resource "aws_s3_bucket" "config_bucket_logs" {
     id      = "30_day_retention_config_bucket_logs"
     enabled = true
     expiration {
-        days = 30
+      days = 30
     }
   }
 

--- a/modules/radius/s3_certificates.tf
+++ b/modules/radius/s3_certificates.tf
@@ -23,7 +23,7 @@ data "template_file" "certificate_bucket_policy" {
   template = file("${path.module}/policies/bucket_policy.json")
 
   vars = {
-    bucket_arn = aws_s3_bucket.certificate_bucket.arn,
+    bucket_arn        = aws_s3_bucket.certificate_bucket.arn,
     ecs_task_role_arn = aws_iam_role.ecs_task_role.arn
   }
 }
@@ -56,7 +56,7 @@ resource "aws_s3_bucket" "certificate_bucket_logs" {
     id      = "30_day_retention_certificate_bucket_logs"
     enabled = true
     expiration {
-        days = 30
+      days = 30
     }
   }
 

--- a/modules/radius/security_groups.tf
+++ b/modules/radius/security_groups.tf
@@ -3,7 +3,7 @@ resource "aws_security_group" "radius_server" {
   description = "Allow ingress and egress traffic for radius server"
   vpc_id      = var.vpc.id
 
-  tags        = var.tags
+  tags = var.tags
 }
 
 resource "aws_security_group_rule" "radius_container_healthcheck" {

--- a/modules/radius/variables.tf
+++ b/modules/radius/variables.tf
@@ -8,13 +8,13 @@ variable "short_prefix" {
 
 variable "vpc" {
   type = object({
-    cidr = string
-    id = string
+    cidr                  = string
+    id                    = string
     private_ip_eu_west_2a = string
     private_ip_eu_west_2b = string
     private_ip_eu_west_2c = string
-    private_subnets = list(string)
-    public_subnets = list(string)
+    private_subnets       = list(string)
+    public_subnets        = list(string)
   })
 }
 
@@ -47,7 +47,7 @@ variable "hosted_zone_domain" {
 }
 
 variable "enable_hosted_zone" {
-  type = bool
+  type    = bool
   default = false
 }
 


### PR DESCRIPTION
Performance testing will generate a large volume of logs, send this to a
temporary log group and point the metrics at this log group for
visibility in Grafana.