### PR TITLE
Publish logs to original log group

### DIFF
--- a/modules/radius/ecs_task_definition.tf
+++ b/modules/radius/ecs_task_definition.tf
@@ -113,7 +113,7 @@ resource "aws_ecs_task_definition" "server_task" {
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
-        "awslogs-group": "${aws_cloudwatch_log_group.server_performance_log_group.name}",
+        "awslogs-group": "${aws_cloudwatch_log_group.server_log_group.name}",
         "awslogs-region": "eu-west-2",
         "awslogs-stream-prefix": "eu-west-2-docker-logs"
       }

--- a/modules/radius/log_metrics.tf
+++ b/modules/radius/log_metrics.tf
@@ -3,7 +3,7 @@ resource "aws_cloudwatch_log_metric_filter" "radius_request_filter" {
 
   name           = replace(each.value, ":", "")
   pattern        = format("\"%s\"", each.value)
-  log_group_name = aws_cloudwatch_log_group.server_performance_log_group.name
+  log_group_name = aws_cloudwatch_log_group.server_log_group.name
 
   metric_transformation {
     name          = replace(each.value, ":", "")

--- a/modules/radius/logging.tf
+++ b/modules/radius/logging.tf
@@ -6,14 +6,6 @@ resource "aws_cloudwatch_log_group" "server_log_group" {
   tags = var.tags
 }
 
-resource "aws_cloudwatch_log_group" "server_performance_log_group" {
-  name = "${var.prefix}-server-performance-log-group"
-
-  retention_in_days = 1
-
-  tags = var.tags
-}
-
 resource "aws_cloudwatch_log_group" "server_nginx_log_group" {
   name = "${var.prefix}-server-nginx-log-group"
 


### PR DESCRIPTION
Performance testing has been concluded and the logs can be discarded.