### PR TITLE
Remove redundant naming from resources

### DIFF
--- a/modules/admin/auto_scaling.tf
+++ b/modules/admin/auto_scaling.tf
@@ -1,6 +1,6 @@
 resource "aws_appautoscaling_target" "admin" {
   service_namespace  = "ecs"
-  resource_id        = "service/${var.radius_cluster_name}/${aws_ecs_service.admin_service.name}"
+  resource_id        = "service/${var.radius_cluster_name}/${aws_ecs_service.admin.name}"
   max_capacity       = 21
   min_capacity       = 3
   scalable_dimension = "ecs:service:DesiredCount"
@@ -10,7 +10,7 @@ resource "aws_appautoscaling_policy" "ecs_policy_up" {
   name               = "${var.prefix} ECS Scale Up"
   service_namespace  = "ecs"
   policy_type        = "StepScaling"
-  resource_id        = "service/${var.radius_cluster_name}/${aws_ecs_service.admin_service.name}"
+  resource_id        = "service/${var.radius_cluster_name}/${aws_ecs_service.admin.name}"
   scalable_dimension = "ecs:service:DesiredCount"
 
   step_scaling_policy_configuration {
@@ -29,7 +29,7 @@ resource "aws_appautoscaling_policy" "ecs_policy_up" {
 resource "aws_appautoscaling_policy" "ecs_policy_down" {
   name               = "ECS Scale Down"
   service_namespace  = "ecs"
-  resource_id        = "service/${var.radius_cluster_name}/${aws_ecs_service.admin_service.name}"
+  resource_id        = "service/${var.radius_cluster_name}/${aws_ecs_service.admin.name}"
   policy_type        = "StepScaling"
   scalable_dimension = "ecs:service:DesiredCount"
 
@@ -58,7 +58,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpu_alarm_high" {
 
   dimensions = {
     ClusterName = var.radius_cluster_name
-    ServiceName = aws_ecs_service.admin_service.name
+    ServiceName = aws_ecs_service.admin.name
   }
 
   alarm_description = "This alarm tells ECS to scale out based on high CPU usage"
@@ -84,7 +84,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpu_alarm_low" {
 
   dimensions = {
     ClusterName = var.radius_cluster_name
-    ServiceName = aws_ecs_service.admin_service.name
+    ServiceName = aws_ecs_service.admin.name
   }
 
   alarm_description = "This alarm tells ECS to scale in based on low CPU usage"

--- a/modules/admin/ecs.tf
+++ b/modules/admin/ecs.tf
@@ -195,7 +195,7 @@ resource "aws_ecs_task_definition" "admin_background_worker" {
   cpu                      = "512"
   memory                   = "2048"
 
-  network_mode             = "awsvpc"
+  network_mode = "awsvpc"
 
   container_definitions = <<EOF
 [

--- a/modules/admin/loadbalancer.tf
+++ b/modules/admin/loadbalancer.tf
@@ -21,7 +21,7 @@ resource "aws_alb_listener" "alb_listener" {
   certificate_arn   = aws_acm_certificate.admin_alb.arn
 
   default_action {
-    target_group_arn = aws_alb_target_group.admin_tg.arn
+    target_group_arn = aws_alb_target_group.admin.arn
     type             = "forward"
   }
   tags = var.tags

--- a/modules/admin/outputs.tf
+++ b/modules/admin/outputs.tf
@@ -9,15 +9,15 @@ output "admin_url" {
 output "ecs" {
   value = {
     cluster_name                   = var.radius_cluster_name
-    service_name                   = aws_ecs_service.admin_service.name
-    background_worker_service_name = aws_ecs_service.admin_background_worker_service.name
-    task_definition_name           = aws_ecs_task_definition.admin_task.id
+    service_name                   = aws_ecs_service.admin.name
+    background_worker_service_name = aws_ecs_service.admin_background_worker.name
+    task_definition_name           = aws_ecs_task_definition.admin.id
   }
 }
 
 output "ecr" {
   value = {
-    repository_url = aws_ecr_repository.admin_ecr.repository_url
+    repository_url = aws_ecr_repository.admin.repository_url
   }
 }
 


### PR DESCRIPTION
The namespace indicates what type of resource it is, no need to repeat
in the name.