### PR TITLE
Update Transit Gateway routes to point to ATOS CIDR

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -23,6 +23,8 @@ env:
     TF_VAR_ocsp_endpoint_ip: "/moj-network-access-control/$ENV/ocsp/endpoint_ip"
     TF_VAR_ocsp_endpoint_port: "/moj-network-access-control/$ENV/ocsp/endpoint_port"
     TF_VAR_ocsp_atos_domain: "/moj-network-access-control/$ENV/ocsp/atos/domain"
+    TF_VAR_ocsp_atos_cidr_range_1: "/moj-network-access-control/$ENV/ocsp/atos/cidr_range_1"
+    TF_VAR_ocsp_atos_cidr_range_2: "/moj-network-access-control/$ENV/ocsp/atos/cidr_range_2"
     TF_VAR_enable_ocsp: "/moj-network-access-control/$ENV/enable_ocsp"
     TF_VAR_ocsp_override_cert_url: "/moj-network-access-control/$ENV/ocsp_override_cert_url"
     TF_VAR_byoip_pool_id: "/moj-network-access-control/$ENV/public_ip_pool_id"

--- a/main.tf
+++ b/main.tf
@@ -150,8 +150,10 @@ module "radius_vpc" {
   transit_gateway_route_table_id        = var.transit_gateway_route_table_id
   mojo_dns_ip_1                         = var.mojo_dns_ip_1
   mojo_dns_ip_2                         = var.mojo_dns_ip_2
-  tags                                  = module.label.tags
   ocsp_endpoint_ip                      = var.ocsp_endpoint_ip
+  ocsp_atos_cidr_range_1                = var.ocsp_atos_cidr_range_1
+  ocsp_atos_cidr_range_2                = var.ocsp_atos_cidr_range_2
+  tags                                  = module.label.tags
 
   providers = {
     aws = aws.env

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -48,16 +48,16 @@ module "vpc" {
   enable_rds_endpoint              = true
   rds_endpoint_private_dns_enabled = true
   rds_endpoint_security_group_ids  = [aws_security_group.endpoints.id]
-  enable_dns_hostnames = true
-  enable_s3_endpoint = true
+  enable_dns_hostnames             = true
+  enable_s3_endpoint               = true
 
   enable_logs_endpoint              = true
   logs_endpoint_private_dns_enabled = true
   logs_endpoint_security_group_ids  = [aws_security_group.endpoints.id]
-  enable_dns_support   = true
-  manage_default_security_group  = true
-  default_security_group_ingress = []
-  default_security_group_egress  = []
+  enable_dns_support                = true
+  manage_default_security_group     = true
+  default_security_group_ingress    = []
+  default_security_group_egress     = []
   private_subnets = [
     cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 0),
     cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 2),

--- a/modules/vpc/routes.tf
+++ b/modules/vpc/routes.tf
@@ -1,6 +1,6 @@
 locals {
   private_table_id = join("_", toset(module.vpc.private_route_table_ids))
-  public_table_id = join("_", toset(module.vpc.public_route_table_ids))
+  public_table_id  = join("_", toset(module.vpc.public_route_table_ids))
 }
 resource "aws_route" "transit-gateway" {
   count = var.enable_nac_transit_gateway_attachment ? length(module.vpc.private_route_table_ids) : 0

--- a/modules/vpc/routes.tf
+++ b/modules/vpc/routes.tf
@@ -18,7 +18,19 @@ resource "aws_route" "transit-gateway-public" {
   count = var.enable_nac_transit_gateway_attachment ? length(module.vpc.public_route_table_ids) : 0
 
   route_table_id         = split("_", local.public_table_id)[count.index]
-  destination_cidr_block = "${var.ocsp_endpoint_ip}/32"
+  destination_cidr_block = var.ocsp_atos_cidr_range_1
+  transit_gateway_id     = var.transit_gateway_id
+
+  depends_on = [
+    module.vpc
+  ]
+}
+
+resource "aws_route" "transit-gateway-public-2" {
+  count = var.enable_nac_transit_gateway_attachment ? length(module.vpc.public_route_table_ids) : 0
+
+  route_table_id         = split("_", local.public_table_id)[count.index]
+  destination_cidr_block = var.ocsp_atos_cidr_range_2
   transit_gateway_id     = var.transit_gateway_id
 
   depends_on = [

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -38,3 +38,11 @@ variable "mojo_dns_ip_1" {
 variable "mojo_dns_ip_2" {
   type = string
 }
+
+variable "ocsp_atos_cidr_range_1" {
+  type = string
+}
+
+variable "ocsp_atos_cidr_range_2" {
+  type = string
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,18 +1,18 @@
-variable cidr_block {
-    type = string
+variable "cidr_block" {
+  type = string
 }
 
 variable "cidr_block_new_bits" {
-    type = number
-    default = 3
+  type    = number
+  default = 3
 }
 
 variable "enable_nac_transit_gateway_attachment" {
-    type = bool
+  type = bool
 }
 
 variable "prefix" {
-    type = string
+  type = string
 }
 
 variable "tags" {
@@ -20,11 +20,11 @@ variable "tags" {
 }
 
 variable "transit_gateway_id" {
-    type = string
+  type = string
 }
 
 variable "transit_gateway_route_table_id" {
-    type = string
+  type = string
 }
 
 variable "ocsp_endpoint_ip" {

--- a/variables.tf
+++ b/variables.tf
@@ -114,3 +114,11 @@ variable "radius_enable_packet_capture" {
 variable "packet_capture_duration_seconds" {
   type = string
 }
+
+variable "ocsp_atos_cidr_range_1" {
+  type = string
+}
+
+variable "ocsp_atos_cidr_range_2" {
+  type = string
+}


### PR DESCRIPTION
This used to be locked down to a single IP, which doesn't make sense if
you're using DNS. Instead point all requests for that CIDR to the
Transit Gateway.