### PR TITLE
Add log filters for "error" and "ERROR"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -107,6 +107,8 @@ module "radius" {
     "Error: post_auth - Failed to find attribute",
     "Error: python",
     "Error:",
+    "ERROR",
+    "error",
     "Shared secret is incorrect",
     "unknown CA",
     "authorized_macs: users: Matched entry",


### PR DESCRIPTION
CloudWatch is case sensitive and "Error" in upper or lower case would be ignored. Add these explicitly, some could be raised by FreeRadius, Python, or Openssl, which all use different versions.