### PR TITLE
🔧 Update log metric filter logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ VpnCerts
 **/pki/*
 *.DS_Store
 .terraform.back
+.infracost

--- a/main.tf
+++ b/main.tf
@@ -106,14 +106,12 @@ module "radius" {
     "Ignoring request to auth address",
     "Error: post_auth - Failed to find attribute",
     "Error: python",
-    "Error:",
-    "ERROR",
-    "error",
     "Shared secret is incorrect",
     "unknown CA",
     "authorized_macs: users: Matched entry",
     "Health Check: OK",
-    "Failed to start task"
+    "Failed to start task",
+    "?'error' ?'Error' ?'ERROR' -'Error: python' -'post_auth - Failed to find attribute'"
   ]
 
   providers = {

--- a/modules/radius/log_metrics.tf
+++ b/modules/radius/log_metrics.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_metric_filter" "radius_request_filter" {
-  for_each = toset(var.log_filters)
+  for_each = toset([for i in var.log_filters : replace(i, ":", "") if !(length(regexall("\\?", i)) > 0) ])
 
   name           = replace(each.value, ":", "")
   pattern        = format("\"%s\"", each.value)
@@ -10,5 +10,21 @@ resource "aws_cloudwatch_log_metric_filter" "radius_request_filter" {
     namespace     = var.log_metrics_namespace
     value         = "1"
     default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "radius_request_filter_with_queries" {
+  for_each = toset([for i in var.log_filters : replace(i, ":", "") if length(regexall("\\?", i)) > 0 ])
+
+  name           = regex("[[:alpha:]]+", each.value)
+  pattern        = replace(each.value, "'", "\"")
+  log_group_name = aws_cloudwatch_log_group.server_log_group.name
+
+  metric_transformation {
+    name          = regex("[[:alpha:]]+", each.value)
+    namespace     = var.log_metrics_namespace
+    value         = "1"
+    default_value = "0"
+    unit          = "count"
   }
 }

--- a/modules/radius/log_metrics.tf
+++ b/modules/radius/log_metrics.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_metric_filter" "radius_request_filter" {
-  for_each = toset([for i in var.log_filters : replace(i, ":", "") if !(length(regexall("\\?", i)) > 0) ])
+  for_each = toset([for i in var.log_filters : replace(i, ":", "") if !(length(regexall("\\?", i)) > 0)])
 
   name           = replace(each.value, ":", "")
   pattern        = format("\"%s\"", each.value)
@@ -14,7 +14,7 @@ resource "aws_cloudwatch_log_metric_filter" "radius_request_filter" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "radius_request_filter_with_queries" {
-  for_each = toset([for i in var.log_filters : replace(i, ":", "") if length(regexall("\\?", i)) > 0 ])
+  for_each = toset([for i in var.log_filters : replace(i, ":", "") if length(regexall("\\?", i)) > 0])
 
   name           = regex("[[:alpha:]]+", each.value)
   pattern        = replace(each.value, "'", "\"")


### PR DESCRIPTION
This commit updates the `aws_cloudwatch_log_metric_filter` resource to account for the scenario where the `log_filters` list in `main.tf` contains entries with queries. The first resource handles 'normal' elements of the list and the latter resource is setup to filter for entries containing '?' and create metrics based off of this.