### PR TITLE
Update log_metrics.tf

### DIFF
--- a/modules/radius/log_metrics.tf
+++ b/modules/radius/log_metrics.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_metric_filter" "radius_request_filter" {
-  for_each = toset([for i in var.log_filters : replace(i, ":", "") if !(length(regexall("\\?", i)) > 0)])
+  for_each = toset([for i in var.log_filters : i if !(length(regexall("\\?", i)) > 0)])
 
   name           = replace(each.value, ":", "")
   pattern        = format("\"%s\"", each.value)
@@ -14,7 +14,7 @@ resource "aws_cloudwatch_log_metric_filter" "radius_request_filter" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "radius_request_filter_with_queries" {
-  for_each = toset([for i in var.log_filters : replace(i, ":", "") if length(regexall("\\?", i)) > 0])
+  for_each = toset([for i in var.log_filters : i if length(regexall("\\?", i)) > 0])
 
   name           = length(regexall("error", each.value)) > 0 ? "All errors" : regex("[[:alpha:]]+", each.value)
   pattern        = replace(each.value, "'", "\"")


### PR DESCRIPTION
Fix the `toset` list so that terraform does not remove `:` from the pattern. It was done in error previously and that caused grafana to fire alerts