### PR TITLE
:lock: Update IAM AWS principal value

### DIFF
--- a/modules/admin/ecs.tf
+++ b/modules/admin/ecs.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 resource "aws_cloudwatch_log_group" "admin" {
   name = var.prefix
 
@@ -26,7 +28,9 @@ resource "aws_ecr_repository_policy" "admin" {
         {
             "Sid": "1",
             "Effect": "Allow",
-            "Principal": "*",
+            "Principal":{ 
+              "AWS": "${data.aws_caller_identity.current.account_id}"
+            },
             "Action": [
                 "ecr:GetDownloadUrlForLayer",
                 "ecr:BatchGetImage",

--- a/modules/radius/ecr.tf
+++ b/modules/radius/ecr.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 resource "aws_ecr_repository" "radius" {
   name                 = var.prefix
   image_tag_mutability = "MUTABLE"
@@ -19,14 +21,9 @@ resource "aws_ecr_repository_policy" "radius" {
         {
             "Sid": "1",
             "Effect": "Allow",
-            "Principal":{
-                "AWS": [
-                    "683290208331",
-                    "068084030754",
-                    "473630360727",
-                    "037161842252"
-                    ]
-                },
+            "Principal":{ 
+              "AWS": "${data.aws_caller_identity.current.account_id}"
+            },
             "Action": [
                 "ecr:GetDownloadUrlForLayer",
                 "ecr:BatchGetImage",

--- a/modules/radius/ecr_nginx.tf
+++ b/modules/radius/ecr_nginx.tf
@@ -8,14 +8,9 @@ resource "aws_ecr_repository_policy" "nginx" {
         {
             "Sid": "1",
             "Effect": "Allow",
-            "Principal":{
-                "AWS": [
-                    "683290208331",
-                    "068084030754",
-                    "473630360727",
-                    "037161842252"
-                    ]
-                },
+            "Principal":{ 
+              "AWS": "${data.aws_caller_identity.current.account_id}"
+            },
             "Action": [
                 "ecr:GetDownloadUrlForLayer",
                 "ecr:BatchGetImage",


### PR DESCRIPTION
This PR locks down the ECR IAM Policy to the AWS account id. 