### PR TITLE
Fix makefile env var sourcing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CURRENT_TIME := `date "+%Y.%m.%d-%H.%M.%S"`
 TERRAFORM_VERSION := `cat versions.tf 2> /dev/null | grep required_version | cut -d "\\"" -f 2 | cut -d " " -f 2`
 
 LOCAL_IMAGE := ministryofjustice/nvvs/terraforms:latest
-DOCKER_IMAGE := ghcr.io/ministryofjustice/nvvs/terraforms:v0.2.0
+DOCKER_IMAGE := ghcr.io/ministryofjustice/nvvs/terraforms:latest
 
 DOCKER_RUN_GEN_ENV := @docker run --rm \
 				--env-file <(aws-vault exec $$AWS_PROFILE -- env | grep ^AWS_) \

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ init: ## terraform init (make init ENV_ARGUMENT=pre-production) NOTE: Will also 
 ## INFO: Do not indent the conditional below, make stops with an error.
 ifneq ("$(wildcard .env)","")
 $(info Using config file ".env")
+include .env
 init: -init
 else
 $(info Config file ".env" does not exist.)


### PR DESCRIPTION
An error was introduced in the previous commit to this file that wasn't spotted.

See line 57
https://github.com/ministryofjustice/network-access-control-infrastructure/commit/d47d99d2f34ef9f70afa224c75593c4c4ad4a0cb