### PR TITLE
CloudWatch log retention update for RDS …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ output: ## terraform output (make output OUTPUT_ARGUMENT='--raw dns_dhcp_vpc_id'
 apply: ## terraform apply
 	$(DOCKER_RUN) /bin/bash -c "terraform apply"
 	$(DOCKER_RUN) /bin/bash -c "./scripts/publish_terraform_outputs.sh"
+	$(DOCKER_RUN) /bin/bash -c "./scripts/cloudwatch_log_retention_policies.sh"
 
 .PHONY: state-list
 state-list: ## terraform state list

--- a/scripts/cloudwatch_log_retention_policies.sh
+++ b/scripts/cloudwatch_log_retention_policies.sh
@@ -11,7 +11,7 @@ fi
 # Filter for log groups containing "aws/rds/instance/" in the name
 log_group_names=$(aws logs describe-log-groups | jq -r '.logGroups | .[] | select(.logGroupName | contains("aws/rds/instance/")) | .logGroupName')
 
-retention_period=7
+retention_period=90
 
 for log_group_name in $log_group_names
 do

--- a/scripts/cloudwatch_log_retention_policies.sh
+++ b/scripts/cloudwatch_log_retention_policies.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Check if the environment is "production"
+if [[ $ENV != "production" ]]; then
+  echo "Script is intended for production environment only. Exiting."
+  exit 0
+fi
+
+# Filter for log groups containing "aws/rds/instance/" in the name
+log_group_names=$(aws logs describe-log-groups | jq -r '.logGroups | .[] | select(.logGroupName | contains("aws/rds/instance/")) | .logGroupName')
+
+retention_period=7
+
+for log_group_name in $log_group_names
+do
+  echo "setting log retention policy for $log_group_name to $retention_period"
+  aws logs put-retention-policy --log-group-name $log_group_name --retention-in-days $retention_period
+done

--- a/scripts/terraform_plan_or_apply.sh
+++ b/scripts/terraform_plan_or_apply.sh
@@ -7,3 +7,7 @@ if [[ "${PLAN}" == "true" ]]; then
 else
   terraform apply --auto-approve -no-color
 fi
+# Run the cloud watch log retention script if in production and apply was successful
+if [[ $ENV == "production" ]] && [[ $? -eq 0 ]]; then
+  bash ./scripts.cloudwatch_log_retention_policies.sh
+fi


### PR DESCRIPTION
added a script to set cloudwatch log retention to 90 days for the RDS log group,as the default is set by the AWS and no configuration option specified elsewhere.