### PR TITLE
575 provide a csv export of mab data from nacs implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ endif
 	$(DOCKER_RUN) /bin/bash -c "terraform init --backend-config=\"key=terraform.${ENV}.state\""
 	$(MAKE) workspace-select
 
+.PHONY: init--reconfigure
+init-reconfigure: ## terraform init --reconfigure
+	$(DOCKER_RUN) /bin/bash -c "terraform init -reconfigure --backend-config=\"key=terraform.${ENV}.state\""
+
 .PHONY: init-upgrade
 init-upgrade: ## terraform init -upgrade
 	$(DOCKER_RUN) /bin/bash -c "terraform init -upgrade --backend-config=\"key=terraform.${ENV}.state\""

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This repository defines the **system infrastructure only**. Specific components 
 - [Authentication with Azure AD](documentation/azure-ad.md)
 - [Vertically scaling the Read Replica](documentation/database-upgrade.md)
 - [Setup Performance Testing](documentation/performance_testing.md)
+- [Database Access - dump with bastion](documentation/rds-bastion.md)
 
 ## CI/CD
 

--- a/bastion-rds-admin.tf
+++ b/bastion-rds-admin.tf
@@ -10,7 +10,7 @@ module "rds_admin_bastion" {
   vpc_id                      = module.admin_vpc.vpc.vpc_id
   vpc_cidr_block              = module.admin_vpc.vpc.vpc_cidr_block
   private_subnets             = module.admin_vpc.public_subnets
-  security_group_ids          = [module.admin.security_group_ids.admin_ecs]
+  security_group_ids          = [module.admin.security_group_ids.admin_ecs, module.admin_vpc.endpoints_sg.id]
   ami_name                    = "diso-devops/bastion/rds-admin/ubuntu-jammy-22.04-amd64-server-1.0.1"
   number_of_bastions          = 1
   assume_role                 = local.s3-mojo_file_transfer_assume_role_arn

--- a/bastion-rds-servers.tf
+++ b/bastion-rds-servers.tf
@@ -10,7 +10,7 @@ module "rds_servers_bastion" {
   vpc_id                      = module.radius_vpc.vpc.vpc_id
   vpc_cidr_block              = module.radius_vpc.vpc.vpc_cidr_block
   private_subnets             = module.radius_vpc.private_subnets
-  security_group_ids          = [module.radius.security_group_ids.radius_server]
+  security_group_ids          = [module.radius.security_group_ids.radius_server, module.radius_vpc.endpoints_sg.id]
   ami_name                    = "diso-devops/bastion/rds-admin/ubuntu-jammy-22.04-amd64-server-1.0.1"
   number_of_bastions          = 1
   assume_role                 = local.s3-mojo_file_transfer_assume_role_arn

--- a/documentation/rds-bastion.md
+++ b/documentation/rds-bastion.md
@@ -1,0 +1,201 @@
+# RDS Bastion
+
+In order to carry out various maintenance tasks such as obtaining a database dump for loading into a local development DB; or obtain data that currently isn't available via an export mechanism; a bastion is created.
+
+The bastion doesn't have any service exposed to the public like a "jump box" bastion e.g. SSH on port 22 as it is only accessible via the AWS Session Manager.
+
+The routine is
+
+- Enable
+  - Enable the bastion via an "enable" flag set in AWS SSM Parameter Store to `true`.
+  - Deploy by running the CI pipeline.
+  - Create an SSM Session.
+  - Carry out required procedure
+
+- Configure
+  - Simple set up to enable assuming a role
+
+- Removal
+  - Disallow the bastion via an "enable" flag set in AWS SSM Parameter Store to `false`.
+  - Omit by running the CI pipeline.
+
+
+## Enable
+
+### Spin up a bastion
+
+Set the boolean value in parameter store to `true`
+run the pipeline
+
+### Get environment details for the target env
+
+```
+make gen-env ENV_ARGUMENT=production
+```
+
+### run the script to identify the bastion instance id
+
+```
+make aws_describe_instances
+```
+
+Then identify the running bastion host
+```
+i-019174128cf7b4563|  t3a.small  |  None           |  running |  mojo-production-rds-admin-bastion
+```
+
+### Start session on bastion
+
+Run make command with instance id
+
+```
+make aws_ssm_start_session INSTANCE_ID=i-019174128cf7b4563
+```
+
+## Configure
+
+First we need to enable an AWS role to transfer files to (or from) an S3 transfer bucket.
+
+```
+#######################
+## Create AWS config ##
+#######################
+
+
+mkdir ~/.aws; \
+cat << 'EOF' > ~/.aws/config
+[profile s3-role]
+role_arn = arn:aws:iam::683290208331:role/s3-mojo-file-transfer-assume-role
+credential_source = Ec2InstanceMetadata
+EOF
+```
+
+now test with the following aws cli command
+
+```
+aws sts get-caller-identity
+```
+
+then access to the s3 bucket
+
+```
+aws s3 ls s3://mojo-file-transfer/ --profile s3-role;
+````
+
+## Get a DB dump
+
+from another terminal window in the root of the project run
+
+```shell
+make shell
+```
+
+the issue a terraform command to get the database details
+
+Admin (dhcp & dns)
+```shell
+terraform output -json terraform_outputs | jq '.admin.db'
+```
+
+DHCP
+```shell
+terraform output -json terraform_outputs | jq '.dhcp.db'
+```
+
+Admin (NAC)* note: NAC code used `rds` as module name.
+```shell
+terraform output -json terraform_outputs | jq '.admin.rds'
+```
+
+To get the password run
+
+```shell
+./scripts/get_db_parameters.sh
+```
+
+##   DHCP Database Backup and Restore
+
+In order to connect to the database the following items will be needed.
+
+- fqdn e.g. `"fqdn": "dhcp-dns-admin-dhcp-db.dev.staff.service.justice.gov.uk",`
+- username e.g. `"username": "adminuser"`
+- password
+
+### Test connection
+
+```shell
+fqdn=dhcp-dns-admin-db.dev.staff.service.justice.gov.uk && curl -v telnet://${fqdn}:3306 --output rds.txt
+```
+
+### Connect to DB
+
+```shell
+fqdn=dhcp-dns-admin-db.dev.staff.service.justice.gov.uk
+admin_db_username=adminuser
+mysql -u ${admin_db_username} -p -h ${fqdn}
+
+## enter password when prompted
+Enter password:
+```
+
+You should see the MySQL command prompt.
+
+```shell
+Welcome to the MySQL monitor.  Commands end with ; or \g.
+Your MySQL connection id is 80936
+Server version: 5.7.42-log Source distribution
+
+Copyright (c) 2000, 2023, Oracle and/or its affiliates.
+
+Oracle is a registered trademark of Oracle Corporation and/or its
+affiliates. Other names may be trademarks of their respective
+owners.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+mysql>
+```
+
+Run some SQL queries to identify the database name etc.
+
+### which databases?
+
+```sql
+mysql>
+show databases;
+```
+
+### Use the database and see the table names
+
+```sql
+mysql> 
+use staffdevicedevelopmentdhcpadmin;
+show tables;
+```
+
+### Get a DB dump
+
+Create a timestamped database dump and upload it to S3 transfer bucket (copy and paste as below, update variable values as required.)
+
+```shell
+env="DEVELOPMENT"; \
+db_name="staffdevicedevelopmentdhcpadmin"; \
+filename="`date "+%Y_%m_%d-%H_%M_%S"`_${env}_${db_name}_rds-dump.sql"; \
+fqdn="dhcp-dns-admin-db.dev.staff.service.justice.gov.uk"; \
+admin_db_username="adminuser"; \
+mysqldump \
+	-u "${admin_db_username}" \
+	-p \
+	--set-gtid-purged=OFF \
+	--triggers --routines --events \
+	-h "${fqdn}"  \
+	"${db_name}" > ~/${filename}; \
+	ls -al; \
+aws s3 cp ~/${filename} s3://mojo-file-transfer/ --profile s3-role; \
+aws s3 ls s3://mojo-file-transfer/ --profile s3-role;
+```
+
+## Removal
+
+Set the boolean value in parameter store to `false`
+run the pipeline

--- a/documentation/rds-bastion.md
+++ b/documentation/rds-bastion.md
@@ -7,18 +7,19 @@ The bastion doesn't have any service exposed to the public like a "jump box" bas
 The routine is
 
 - Enable
+
   - Enable the bastion via an "enable" flag set in AWS SSM Parameter Store to `true`.
   - Deploy by running the CI pipeline.
   - Create an SSM Session.
   - Carry out required procedure
 
 - Configure
+
   - Simple set up to enable assuming a role
 
 - Removal
   - Disallow the bastion via an "enable" flag set in AWS SSM Parameter Store to `false`.
   - Omit by running the CI pipeline.
-
 
 ## Enable
 
@@ -40,6 +41,7 @@ make aws_describe_instances
 ```
 
 Then identify the running bastion host
+
 ```
 i-019174128cf7b4563|  t3a.small  |  None           |  running |  mojo-production-rds-admin-bastion
 ```
@@ -80,7 +82,7 @@ then access to the s3 bucket
 
 ```
 aws s3 ls s3://mojo-file-transfer/ --profile s3-role;
-````
+```
 
 ## Get a DB dump
 
@@ -93,16 +95,19 @@ make shell
 the issue a terraform command to get the database details
 
 Admin (dhcp & dns)
+
 ```shell
 terraform output -json terraform_outputs | jq '.admin.db'
 ```
 
 DHCP
+
 ```shell
 terraform output -json terraform_outputs | jq '.dhcp.db'
 ```
 
-Admin (NAC)* note: NAC code used `rds` as module name.
+Admin (NAC)\* note: NAC code used `rds` as module name.
+
 ```shell
 terraform output -json terraform_outputs | jq '.admin.rds'
 ```
@@ -113,7 +118,7 @@ To get the password run
 ./scripts/get_db_parameters.sh
 ```
 
-##   DHCP Database Backup and Restore
+## DHCP Database Backup and Restore
 
 In order to connect to the database the following items will be needed.
 
@@ -168,7 +173,7 @@ show databases;
 ### Use the database and see the table names
 
 ```sql
-mysql> 
+mysql>
 use staffdevicedevelopmentdhcpadmin;
 show tables;
 ```

--- a/modules/admin/outputs.tf
+++ b/modules/admin/outputs.tf
@@ -26,11 +26,11 @@ output "rds" {
     admin_db_id         = var.run_restore_from_backup ? element(aws_db_instance.admin_db_restored.*.id, 0) : aws_db_instance.admin_db.id
     admin_db_arn        = var.run_restore_from_backup ? element(aws_db_instance.admin_db_restored.*.arn, 0) : aws_db_instance.admin_db.arn
     rds_monitoring_role = aws_iam_role.rds_monitoring_role.arn
-    fqdn = aws_route53_record.admin_db.fqdn
-    endpoint = aws_db_instance.admin_db.endpoint
-    name = aws_db_instance.admin_db.name
-    port = aws_db_instance.admin_db.port
-    username = aws_db_instance.admin_db.username
+    fqdn                = aws_route53_record.admin_db.fqdn
+    endpoint            = aws_db_instance.admin_db.endpoint
+    name                = aws_db_instance.admin_db.name
+    port                = aws_db_instance.admin_db.port
+    username            = aws_db_instance.admin_db.username
   }
 }
 

--- a/modules/admin/outputs.tf
+++ b/modules/admin/outputs.tf
@@ -26,6 +26,11 @@ output "rds" {
     admin_db_id         = var.run_restore_from_backup ? element(aws_db_instance.admin_db_restored.*.id, 0) : aws_db_instance.admin_db.id
     admin_db_arn        = var.run_restore_from_backup ? element(aws_db_instance.admin_db_restored.*.arn, 0) : aws_db_instance.admin_db.arn
     rds_monitoring_role = aws_iam_role.rds_monitoring_role.arn
+    fqdn = aws_route53_record.admin_db.fqdn
+    endpoint = aws_db_instance.admin_db.endpoint
+    name = aws_db_instance.admin_db.name
+    port = aws_db_instance.admin_db.port
+    username = aws_db_instance.admin_db.username
   }
 }
 

--- a/modules/admin_vpc/outputs.tf
+++ b/modules/admin_vpc/outputs.tf
@@ -21,3 +21,23 @@ output "public_route_table_ids" {
 output "vpc" {
   value = module.vpc
 }
+
+output "vpc_brief" {
+  value = {
+    azs                         = module.vpc.azs
+    id                          = module.vpc.vpc_id
+    name                        = module.vpc.name
+    private_route_table_ids     = module.vpc.private_route_table_ids
+    private_subnets             = module.vpc.private_subnets
+    private_subnets_cidr_blocks = module.vpc.private_subnets_cidr_blocks
+    public_route_table_ids      = module.vpc.public_route_table_ids
+    public_subnets              = module.vpc.public_subnets
+    public_subnets_cidr_blocks  = module.vpc.public_subnets_cidr_blocks
+  }
+}
+
+output "endpoints_sg" {
+  value = {
+    id = aws_security_group.endpoints.id
+  }
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -21,3 +21,23 @@ output "private_route_table_ids" {
 output "vpc" {
   value = module.vpc
 }
+
+output "vpc_brief" {
+  value = {
+    azs                         = module.vpc.azs
+    id                          = module.vpc.vpc_id
+    name                        = module.vpc.name
+    private_route_table_ids     = module.vpc.private_route_table_ids
+    private_subnets             = module.vpc.private_subnets
+    private_subnets_cidr_blocks = module.vpc.private_subnets_cidr_blocks
+    public_route_table_ids      = module.vpc.public_route_table_ids
+    public_subnets              = module.vpc.public_subnets
+    public_subnets_cidr_blocks  = module.vpc.public_subnets_cidr_blocks
+  }
+}
+
+output "endpoints_sg" {
+  value = {
+    id = aws_security_group.endpoints.id
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,10 +4,13 @@ output "terraform_outputs" {
       ecs = module.radius.ecs
       ecr = module.radius.ecr
       s3  = module.radius.s3
+      vpc = module.radius_vpc.vpc_brief
     }
     admin = {
       ecr = module.admin.ecr
       ecs = module.admin.ecs
+      rds = module.admin.rds
+      vpc = module.admin_vpc.vpc_brief
     }
   }
 }

--- a/scripts/aws_ssm_set_parameters.sh
+++ b/scripts/aws_ssm_set_parameters.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+ENV="${1:-development}"
+ENABLE_RDS_SERVERS_BASTION="${2:-false}"
+ENABLE_RDS_ADMIN_BASTION="${3:-false}"
+
+echo $ENV
+
+#aws ssm put-parameter \
+#    --name "/moj-network-access-control/$ENV/enable_rds_servers_bastion" \
+#    --type "String" \
+#    --value "$ENABLE_RDS_SERVERS_BASTION" \
+#    --overwrite
+#
+#aws ssm put-parameter \
+#    --name "/moj-network-access-control/$ENV/enable_rds_admin_bastion" \
+#    --type "String" \
+#    --value "$ENABLE_RDS_ADMIN_BASTION" \
+#    --overwrite
+
+
+export PARAM=$(aws ssm get-parameters --region eu-west-2 --with-decryption --names \
+    "/moj-network-access-control/$ENV/enable_rds_admin_bastion" \
+    "/moj-network-access-control/$ENV/enable_rds_servers_bastion" \
+    --query Parameters)
+
+echo $ENV
+echo $PARAM
+
+declare -A params
+
+params["enable_rds_servers_bastion"]="$(echo $PARAM | jq '.[] | select(.Name | test("enable_rds_servers_bastion")) | .Value' --raw-output)"
+params["enable_rds_admin_bastion"]="$(echo $PARAM | jq '.[] | select(.Name | test("enable_rds_admin_bastion")) | .Value' --raw-output)"
+
+for key in "${!params[@]}"
+do
+  echo "${key}=${params[${key}]}"
+done

--- a/scripts/get_db_parameters.sh
+++ b/scripts/get_db_parameters.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+export PARAM=$(aws ssm get-parameters --region eu-west-2 --with-decryption --names \
+    "/moj-network-access-control/$ENV/admin_db_username" \
+    "/moj-network-access-control/$ENV/admin_db_password" \
+    --query Parameters)
+
+echo $ENV
+echo $PARAM
+
+declare -A params
+
+params["admin_db_password"]="$(echo $PARAM | jq '.[] | select(.Name | test("admin_db_password")) | .Value' --raw-output)"
+params["admin_db_username"]="$(echo $PARAM | jq '.[] | select(.Name | test("admin_db_username")) | .Value' --raw-output)"
+
+
+for key in "${!params[@]}"
+do
+  echo "${key}=${params[${key}]}"
+done


### PR DESCRIPTION
This code change adds the implementation of the RDS bastion as used in DHCP and DNS Infra project, for operation tasks in which direct access to the MySQL database is necessary.

Documentation for usage has been written and included.