### PR TITLE
Update Parameter tier for terraform outputs

### DIFF
--- a/scripts/publish_terraform_outputs.sh
+++ b/scripts/publish_terraform_outputs.sh
@@ -8,4 +8,5 @@ aws ssm put-parameter --name "/moj-network-access-control/terraform/$ENV/outputs
   --description "Terraform outputs that other pipelines or processes depend on" \
   --value "$terraform_outputs" \
   --type String \
+  --tier Intelligent-Tiering \
   --overwrite


### PR DESCRIPTION
During the publish terraform outputs operation the script could fail because the data has exceeded the standard tier of 4KB. Specifying "Intelligent-Tiering" for this parameter so that it will default to "Advanced" 8KB when necessary.