### PR TITLE
Updated WAF Rules

### DIFF
--- a/modules/admin/waf.tf
+++ b/modules/admin/waf.tf
@@ -13,8 +13,156 @@ resource "aws_wafv2_web_acl" "admin_alb_acl" {
   }
 
   rule {
-    name     = "only-gb"
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
     priority = 1
+    override_action {
+      none {
+      }
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.prefix}-AWS-AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesAdminProtectionRuleSet"
+    priority = 2
+    override_action {
+      none {
+      }
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAdminProtectionRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.prefix}-AWS-AWSManagedRulesAdminProtectionRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 3
+    override_action {
+      none {
+      }
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.prefix}-AWS-AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesLinuxRuleSet"
+    priority = 4
+    override_action {
+      none {
+      }
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesLinuxRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.prefix}-AWS-AWSManagedRulesLinuxRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesUnixRuleSet"
+    priority = 5
+    override_action {
+      none {
+      }
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesUnixRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.prefix}-AWS-AWSManagedRulesUnixRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesAmazonIpReputationList"
+    priority = 6
+    override_action {
+      none {
+      }
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.prefix}-AWS-AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesBotControlRuleSet"
+    priority = 7
+    override_action {
+      none {
+      }
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesBotControlRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.prefix}-AWS-AWSManagedRulesBotControlRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    // This rule should always be the last rule in the list
+    name     = "only-gb"
+    priority = 15
     action {
       allow {}
     }
@@ -27,7 +175,7 @@ resource "aws_wafv2_web_acl" "admin_alb_acl" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = var.prefix
+      metric_name                = "${var.prefix}-only-gb"
       sampled_requests_enabled   = true
     }
   }


### PR DESCRIPTION
Updated the WAF rules to use AWS managed rules to protet the service from bad actors.

Added the following rules:

AWSManagedRulesCommonRuleSet
AWSManagedRulesAdminProtectionRuleSet
AWSManagedRulesKnownBadInputsRuleSet
AWSManagedRulesLinuxRuleSet
AWSManagedRulesUnixRuleSet
AWSManagedRulesAmazonIpReputationList
AWSManagedRulesBotControlRuleSet

Set the last priority rule to only allow gb

https://docs.aws.amazon.com/pdfs/waf/latest/developerguide/waf-dg.pdf#aws-managed-rule-groups-list