### PR TITLE
Nd 140 redeploy nac nlb with security group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,10 +155,12 @@ aws_ssm_start_session: ## Use AWS CLI to start SSM session on an EC2 instance (m
 tfenv: ## tfenv pin - terraform version from versions.tf
 	tfenv use $(cat versions.tf 2> /dev/null | grep required_version | cut -d "\"" -f 2 | cut -d " " -f 2) && tfenv pin
 
+.PHONY: taint
+taint: ## terraform taint (make taint TAINT_ARGUMENT=module.radius.aws_lb.load_balancer)
+	$(DOCKER_RUN) /bin/bash -c "terraform taint -no-color ${TAINT_ARGUMENT}"
+
 help:
 	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
-
-
 
 ############ Repository unique targets ############
 .PHONY: authorise-performance-test-clients

--- a/modules/radius/load_balancer.tf
+++ b/modules/radius/load_balancer.tf
@@ -3,7 +3,7 @@ resource "aws_lb" "load_balancer" {
   load_balancer_type               = "network"
   internal                         = false
   enable_cross_zone_load_balancing = true
-  security_groups    = [aws_security_group.nlb_public.id]
+  security_groups                  = [aws_security_group.nlb_public.id]
   access_logs {
     bucket  = aws_s3_bucket.lb_log_bucket.bucket
     enabled = true
@@ -233,15 +233,19 @@ resource "aws_security_group" "nlb_public" {
   name   = "${var.prefix}-nlb-public"
   vpc_id = var.vpc.id
 
+  tags = merge(var.tags, {
+    Name = "${var.prefix}-nlb-public"
+  })
+
   dynamic "ingress" {
     for_each = var.ingress_rules
 
     content {
-      from_port       = ingress.value.from_port
-      to_port         = ingress.value.to_port
-      protocol        = ingress.value.protocol
-      cidr_blocks     = ingress.value.cidr_blocks
-      description     = ingress.value.description
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+      description = ingress.value.description
     }
   }
 
@@ -249,11 +253,11 @@ resource "aws_security_group" "nlb_public" {
     for_each = var.egress_rules
 
     content {
-      from_port       = egress.value.from_port
-      to_port         = egress.value.to_port
-      protocol        = egress.value.protocol
-      cidr_blocks     = egress.value.cidr_blocks
-      description     = egress.value.description
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+      description = egress.value.description
     }
   }
 }

--- a/modules/radius/load_balancer.tf
+++ b/modules/radius/load_balancer.tf
@@ -3,6 +3,7 @@ resource "aws_lb" "load_balancer" {
   load_balancer_type               = "network"
   internal                         = false
   enable_cross_zone_load_balancing = true
+  security_groups    = [aws_security_group.nlb_public.id]
   access_logs {
     bucket  = aws_s3_bucket.lb_log_bucket.bucket
     enabled = true
@@ -174,3 +175,85 @@ resource "aws_kms_key" "lb_log_bucket_key" {
   enable_key_rotation     = true
 }
 
+//Security group for PUBLIC NLB
+
+variable "ingress_rules" {
+  type = list(object({
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    cidr_blocks = list(string)
+    description = string
+  }))
+  default = [
+    {
+      from_port   = 8000
+      to_port     = 8000
+      protocol    = "tcp"
+      cidr_blocks = ["10.180.108.0/22"]
+      description = "Allow load balancer health checks"
+    },
+    {
+      from_port   = 2083
+      to_port     = 2083
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = " Allow inbound RADSEC traffic to the Radius server"
+    },
+    {
+      from_port   = 1812
+      to_port     = 1812
+      protocol    = "udp"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "Allow inbound EAP traffic to the Radius server"
+    }
+  ]
+}
+
+variable "egress_rules" {
+  type = list(object({
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    cidr_blocks = list(string)
+    description = string
+  }))
+  default = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "Allow all outbound traffic"
+    }
+  ]
+}
+
+resource "aws_security_group" "nlb_public" {
+  name   = "${var.prefix}-nlb-public"
+  vpc_id = var.vpc.id
+
+  dynamic "ingress" {
+    for_each = var.ingress_rules
+
+    content {
+      from_port       = ingress.value.from_port
+      to_port         = ingress.value.to_port
+      protocol        = ingress.value.protocol
+      cidr_blocks     = ingress.value.cidr_blocks
+      description     = ingress.value.description
+    }
+  }
+
+  dynamic "egress" {
+    for_each = var.egress_rules
+
+    content {
+      from_port       = egress.value.from_port
+      to_port         = egress.value.to_port
+      protocol        = egress.value.protocol
+      cidr_blocks     = egress.value.cidr_blocks
+      description     = egress.value.description
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,7 @@ output "terraform_outputs" {
     radius = {
       ecs = module.radius.ecs
       ecr = module.radius.ecr
+      lb  = module.radius.load_balancer
       s3  = module.radius.s3
       vpc = module.radius_vpc.vpc_brief
     }


### PR DESCRIPTION
- This PR will redeploy NLB to include security group 
- Security group rule will have the same rules as the task in NACs service
- Added Taint to make file(this is useful for when we need to force redeploy resources)