### PR TITLE
 Added NAT gateway for the OCSP route to DEP

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -41,6 +41,7 @@ env:
     TF_VAR_shared_services_account_id: "/codebuild/staff_device_shared_services_account_id"
     TF_VAR_enable_rds_admin_bastion: "/moj-network-access-control/$ENV/enable_rds_admin_bastion"
     TF_VAR_enable_rds_servers_bastion: "/moj-network-access-control/$ENV/enable_rds_servers_bastion"
+    TF_VAR_ocsp_dep_ip: "/moj-network-access-control/$ENV/ocsp_dep_ip"
 
 phases:
   install:

--- a/main.tf
+++ b/main.tf
@@ -157,6 +157,7 @@ module "radius_vpc" {
   ocsp_atos_cidr_range_2                = var.ocsp_atos_cidr_range_2
   tags                                  = module.label.tags
   ssm_session_manager_endpoints         = var.enable_rds_servers_bastion
+  ocsp_dep_ip                           = var.ocsp_dep_ip
 
   providers = {
     aws = aws.env

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -31,7 +31,6 @@ module "vpc" {
     "eu-west-2b",
     "eu-west-2c"
   ]
-
   enable_ecr_dkr_endpoint              = true
   enable_ecr_api_endpoint              = true
   ecr_api_endpoint_security_group_ids  = [aws_security_group.endpoints.id]

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -41,3 +41,8 @@ output "endpoints_sg" {
     id = aws_security_group.endpoints.id
   }
 }
+output "nat_gateway_eip" {
+  value = {
+    id = aws_nat_gateway.eu_west_2a.public_ip
+  }
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -33,6 +33,7 @@ output "vpc_brief" {
     public_route_table_ids      = module.vpc.public_route_table_ids
     public_subnets              = module.vpc.public_subnets
     public_subnets_cidr_blocks  = module.vpc.public_subnets_cidr_blocks
+    internet_gateway_id         = module.vpc.igw_id
   }
 }
 
@@ -43,6 +44,12 @@ output "endpoints_sg" {
 }
 output "nat_gateway_eip" {
   value = {
-    id = aws_nat_gateway.eu_west_2a.public_ip
+    id = aws_nat_gateway.eu_west_2c.public_ip
   }
+}
+output "nat_gateway_subnet_id" {
+  value = element(module.vpc.private_subnets, 2)
+}
+output "nat_gateway_route_table_id" {
+  value = element(module.vpc.private_route_table_ids, 2)
 }

--- a/modules/vpc/routes.tf
+++ b/modules/vpc/routes.tf
@@ -1,11 +1,11 @@
 locals {
-  private_table_id = join("_", toset(module.vpc.private_route_table_ids))
-  public_table_id  = join("_", toset(module.vpc.public_route_table_ids))
+  private_table_id     = join("_", toset(module.vpc.private_route_table_ids))
+  public_table_id      = join("_", toset(module.vpc.public_route_table_ids))
+  nat_gateway_table_id = join("_", toset([module.vpc.private_route_table_ids[2]]))
 }
 resource "aws_route" "transit-gateway" {
-  count = var.enable_nac_transit_gateway_attachment ? length(module.vpc.private_route_table_ids) : 0
-
-  route_table_id         = split("_", local.private_table_id)[count.index]
+  count = var.enable_nac_transit_gateway_attachment ? 2 : 0
+  route_table_id         = element(module.vpc.private_route_table_ids, count.index)
   destination_cidr_block = "0.0.0.0/0"
   transit_gateway_id     = var.transit_gateway_id
 
@@ -62,32 +62,44 @@ resource "aws_route" "transit-gateway-public-dns-server-2" {
   ]
 }
 
+
+# Updating Public Routes for OCSP DEP
 resource "aws_route" "nat-gateway-public-ocsp-endpoint-1" {
   count = length(module.vpc.public_route_table_ids)
 
   route_table_id         = split("_", local.public_table_id)[count.index]
   destination_cidr_block = "${var.ocsp_dep_ip}/32"
-  nat_gateway_id         = aws_nat_gateway.eu_west_2a.id
+  nat_gateway_id         = aws_nat_gateway.eu_west_2c.id
 
   depends_on = [
     module.vpc
   ]
 }
 
-resource "aws_nat_gateway" "eu_west_2a" {
-  allocation_id = aws_eip.nat_eu_west_2a.id
-  subnet_id     = module.vpc.public_subnets[0]
-
-  tags = var.tags
-
+resource "aws_nat_gateway" "eu_west_2c" {
+  allocation_id = aws_eip.nat_eu_west_2c.id
+  subnet_id     = element(module.vpc.private_subnets, 2)
+  tags          = var.tags
   depends_on = [
     module.vpc
   ]
 }
-resource "aws_eip" "nat_eu_west_2a" {
+
+resource "aws_eip" "nat_eu_west_2c" {
   vpc  = true
   tags = var.tags
   depends_on = [
     module.vpc
   ]
 }
+#add public route to nat gateway subnet
+resource "aws_route" "nat_gateway_subnet_internet_access" {
+  route_table_id         = local.nat_gateway_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = module.vpc.igw_id
+
+  depends_on = [
+    module.vpc
+  ]
+}
+

--- a/modules/vpc/routes.tf
+++ b/modules/vpc/routes.tf
@@ -61,3 +61,33 @@ resource "aws_route" "transit-gateway-public-dns-server-2" {
     module.vpc
   ]
 }
+
+resource "aws_route" "nat-gateway-public-ocsp-endpoint-1" {
+  count = length(module.vpc.public_route_table_ids)
+
+  route_table_id         = split("_", local.public_table_id)[count.index]
+  destination_cidr_block = "${var.ocsp_dep_ip}/32"
+  nat_gateway_id         = aws_nat_gateway.eu_west_2a.id
+
+  depends_on = [
+    module.vpc
+  ]
+}
+
+resource "aws_nat_gateway" "eu_west_2a" {
+  allocation_id = aws_eip.nat_eu_west_2a.id
+  subnet_id     = module.vpc.public_subnets[0]
+
+  tags = var.tags
+
+  depends_on = [
+    module.vpc
+  ]
+}
+resource "aws_eip" "nat_eu_west_2a" {
+  vpc  = true
+  tags = var.tags
+  depends_on = [
+    module.vpc
+  ]
+}

--- a/modules/vpc/routes.tf
+++ b/modules/vpc/routes.tf
@@ -4,7 +4,7 @@ locals {
   nat_gateway_table_id = join("_", toset([module.vpc.private_route_table_ids[2]]))
 }
 resource "aws_route" "transit-gateway" {
-  count = var.enable_nac_transit_gateway_attachment ? 2 : 0
+  count                  = var.enable_nac_transit_gateway_attachment ? 2 : 0
   route_table_id         = element(module.vpc.private_route_table_ids, count.index)
   destination_cidr_block = "0.0.0.0/0"
   transit_gateway_id     = var.transit_gateway_id

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -55,3 +55,7 @@ variable "ssm_session_manager_endpoints" {
   type    = bool
   default = false
 }
+
+variable "ocsp_dep_ip" {
+  type = string
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,8 +13,14 @@ output "terraform_outputs" {
       rds = module.admin.rds
       vpc = module.admin_vpc.vpc_brief
     }
-    nat_gateway_public_ip= {
-      value = module.radius_vpc.nat_gateway_eip
+        nat_gateway_public_ip = {
+          value = module.radius_vpc.nat_gateway_eip
+        }
+    nat_gateway_subnet = {
+      value = module.radius_vpc.nat_gateway_subnet_id
+    }
+    nat_gateway_route_table = {
+      value = module.radius_vpc.nat_gateway_route_table_id
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,9 +13,9 @@ output "terraform_outputs" {
       rds = module.admin.rds
       vpc = module.admin_vpc.vpc_brief
     }
-        nat_gateway_public_ip = {
-          value = module.radius_vpc.nat_gateway_eip
-        }
+    nat_gateway_public_ip = {
+      value = module.radius_vpc.nat_gateway_eip
+    }
     nat_gateway_subnet = {
       value = module.radius_vpc.nat_gateway_subnet_id
     }

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,5 +13,8 @@ output "terraform_outputs" {
       rds = module.admin.rds
       vpc = module.admin_vpc.vpc_brief
     }
+    nat_gateway_public_ip= {
+      value = module.radius_vpc.nat_gateway_eip
+    }
   }
 }

--- a/scripts/aws_ssm_get_parameters.sh
+++ b/scripts/aws_ssm_get_parameters.sh
@@ -40,6 +40,7 @@ export PARAM3=$(aws ssm get-parameters --region eu-west-2 --with-decryption --na
 export PARAM4=$(aws ssm get-parameters --region eu-west-2 --with-decryption --names \
     "/moj-network-access-control/$ENV/enable_rds_admin_bastion" \
     "/moj-network-access-control/$ENV/enable_rds_servers_bastion" \
+    "/moj-network-access-control/$ENV/ocsp_dep_ip" \
     --query Parameters)
 
 declare -A parameters
@@ -80,3 +81,4 @@ parameters["shared_services_account_id"]="$(echo $PARAM3 | jq '.[] | select(.Nam
 
 parameters["enable_rds_servers_bastion"]="$(echo $PARAM4 | jq '.[] | select(.Name | test("enable_rds_servers_bastion")) | .Value' --raw-output)"
 parameters["enable_rds_admin_bastion"]="$(echo $PARAM4 | jq '.[] | select(.Name | test("enable_rds_admin_bastion")) | .Value' --raw-output)"
+parameters["ocsp_dep_ip"]="$(echo $PARAM4 | jq '.[] | select(.Name | test("ocsp_dep_ip")) | .Value' --raw-output)"

--- a/variables.tf
+++ b/variables.tf
@@ -146,3 +146,7 @@ variable "enable_rds_servers_bastion" {
   type    = bool
   default = false
 }
+
+variable "ocsp_dep_ip" {
+  type = string
+}


### PR DESCRIPTION
- Deploys NAT Gateway with Elastic IP in Radius VPC
- Assigns NAT to the public route table with specific destination IP for OCSP DEP
- updates the gen-env script to accomodate new ssm parameter for ocsp_dep_ip
**Limitations acknowledged **
- **single** NAT could impact availability issue in the event of an AZ failure as the there are only one route table for public subnet. 
