### PR TITLE
added OCSP destination IP for PRS to be routed via NAT gateway on the…

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -42,6 +42,7 @@ env:
     TF_VAR_enable_rds_admin_bastion: "/moj-network-access-control/$ENV/enable_rds_admin_bastion"
     TF_VAR_enable_rds_servers_bastion: "/moj-network-access-control/$ENV/enable_rds_servers_bastion"
     TF_VAR_ocsp_dep_ip: "/moj-network-access-control/$ENV/ocsp_dep_ip"
+    TF_VAR_ocsp_prs_ip: "/moj-network-access-control/$ENV/ocsp_prs_ip"
 
 phases:
   install:

--- a/main.tf
+++ b/main.tf
@@ -160,6 +160,7 @@ module "radius_vpc" {
   tags                                  = module.label.tags
   ssm_session_manager_endpoints         = var.enable_rds_servers_bastion
   ocsp_dep_ip                           = var.ocsp_dep_ip
+  ocsp_prs_ip                           = var.ocsp_prs_ip
 
   providers = {
     aws = aws.env

--- a/modules/vpc/routes.tf
+++ b/modules/vpc/routes.tf
@@ -75,6 +75,17 @@ resource "aws_route" "nat-gateway-public-ocsp-endpoint-1" {
     module.vpc
   ]
 }
+resource "aws_route" "nat-gateway-public-ocsp-endpoint-2" {
+  count = length(module.vpc.public_route_table_ids)
+
+  route_table_id         = split("_", local.public_table_id)[count.index]
+  destination_cidr_block = "${var.ocsp_prs_ip}/32"
+  nat_gateway_id         = aws_nat_gateway.eu_west_2c.id
+
+  depends_on = [
+    module.vpc
+  ]
+}
 
 resource "aws_nat_gateway" "eu_west_2c" {
   allocation_id = aws_eip.nat_eu_west_2c.id

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -59,3 +59,7 @@ variable "ssm_session_manager_endpoints" {
 variable "ocsp_dep_ip" {
   type = string
 }
+
+variable "ocsp_prs_ip" {
+  type = string
+}

--- a/scripts/aws_ssm_get_parameters.sh
+++ b/scripts/aws_ssm_get_parameters.sh
@@ -41,6 +41,7 @@ export PARAM4=$(aws ssm get-parameters --region eu-west-2 --with-decryption --na
     "/moj-network-access-control/$ENV/enable_rds_admin_bastion" \
     "/moj-network-access-control/$ENV/enable_rds_servers_bastion" \
     "/moj-network-access-control/$ENV/ocsp_dep_ip" \
+    "/moj-network-access-control/$ENV/ocsp_prs_ip" \
     --query Parameters)
 
 declare -A parameters
@@ -82,3 +83,4 @@ parameters["shared_services_account_id"]="$(echo $PARAM3 | jq '.[] | select(.Nam
 parameters["enable_rds_servers_bastion"]="$(echo $PARAM4 | jq '.[] | select(.Name | test("enable_rds_servers_bastion")) | .Value' --raw-output)"
 parameters["enable_rds_admin_bastion"]="$(echo $PARAM4 | jq '.[] | select(.Name | test("enable_rds_admin_bastion")) | .Value' --raw-output)"
 parameters["ocsp_dep_ip"]="$(echo $PARAM4 | jq '.[] | select(.Name | test("ocsp_dep_ip")) | .Value' --raw-output)"
+parameters["ocsp_prs_ip"]="$(echo $PARAM4 | jq '.[] | select(.Name | test("ocsp_prs_ip")) | .Value' --raw-output)"

--- a/variables.tf
+++ b/variables.tf
@@ -156,3 +156,7 @@ variable "allowed_ips" {
   description = "List of allowed IP addresses"
   default     = []
 }
+
+variable "ocsp_prs_ip" {
+  type = string
+}


### PR DESCRIPTION
- NACs Public route table updated to reflect PRS OCSP endpoint to be routed via NAT

DEV Only at this moment therefore do not merge this PR until we get the IPs for Production OCSP Endpoint too 