### PR TITLE
replacing current owner-email default entry for user who has left with lanwifi-devops@digital.justice.gov.uk

### DIFF
--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -5,6 +5,6 @@ variable "is_production" {
 
 variable "owner_email" {
   type    = string
-  default = "emile.swarts@digital.justice.gov.uk"
+  default = "lanwifi-devops@digital.justice.gov.uk"
 }
 


### PR DESCRIPTION
replacing current owner-email default entry for user who has left with lanwifi-devops@digital.justice.gov.uk ND-187