### PR TITLE
Updated s3 resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,9 @@ init-upgrade: ## terraform init -upgrade
 unlock: ## Terraform unblock (make unlock ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
 	$(DOCKER_RUN) /bin/bash -c "terraform force-unlock ${ID}"
 
-# .PHONY: import
-# import: ## terraform import e.g. (make import IMPORT_ARGUMENT=module.foo.bar some_resource)
-# 	$(DOCKER_RUN) /bin/bash -c "terraform import ${IMPORT_ARGUMENT}"
+.PHONY: import
+import: ## terraform import e.g. (make import IMPORT_ARGUMENT=module.foo.bar some_resource)
+	$(DOCKER_RUN) /bin/bash -c "terraform import ${IMPORT_ARGUMENT}"
 
 .PHONY: workspace-list
 workspace-list: ## terraform workspace list
@@ -166,7 +166,3 @@ help:
 .PHONY: authorise-performance-test-clients
 authorise-performance-test-clients: ## Update a config file with IPs for test clients
 	$(DOCKER_RUN) /bin/bash -c "./scripts/authorise_performance_test_clients.sh"
-
-.PHONY: import
-import: ## terraform import
-	$(DOCKER_RUN) /bin/bash -c "terraform import module.radius.aws_s3_bucket_acl.certificate_bucket_logs_acl mojo-development-nac-certificate-bucket-logs"

--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,9 @@ init-upgrade: ## terraform init -upgrade
 unlock: ## Terraform unblock (make unlock ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
 	$(DOCKER_RUN) /bin/bash -c "terraform force-unlock ${ID}"
 
-.PHONY: import
-import: ## terraform import e.g. (make import IMPORT_ARGUMENT=module.foo.bar some_resource)
-	$(DOCKER_RUN) /bin/bash -c "terraform import ${IMPORT_ARGUMENT}"
+# .PHONY: import
+# import: ## terraform import e.g. (make import IMPORT_ARGUMENT=module.foo.bar some_resource)
+# 	$(DOCKER_RUN) /bin/bash -c "terraform import ${IMPORT_ARGUMENT}"
 
 .PHONY: workspace-list
 workspace-list: ## terraform workspace list
@@ -94,7 +94,7 @@ workspace-select: ## terraform workspace select
 
 .PHONY: validate
 validate: ## terraform validate
-	$(DOCKER_RUN) /bin/bash -c "terraform validate"
+	$(DOCKER_RUN) /bin/bash -c "terraform validate -json"
 
 .PHONY: plan-out
 plan-out: ## terraform plan - output to timestamped file
@@ -157,7 +157,7 @@ tfenv: ## tfenv pin - terraform version from versions.tf
 
 .PHONY: taint
 taint: ## terraform taint (make taint TAINT_ARGUMENT=module.radius.aws_lb.load_balancer)
-	$(DOCKER_RUN) /bin/bash -c "terraform taint -no-color ${TAINT_ARGUMENT}"
+	 taint -no-color ${TAINT_ARGUMENT}"
 
 help:
 	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -166,3 +166,11 @@ help:
 .PHONY: authorise-performance-test-clients
 authorise-performance-test-clients: ## Update a config file with IPs for test clients
 	$(DOCKER_RUN) /bin/bash -c "./scripts/authorise_performance_test_clients.sh"
+
+.PHONY: import
+import: ## terraform import
+	$(DOCKER_RUN) /bin/bash -c "terraform import module.performance_testing[0].aws_s3_bucket_server_side_encryption_configuration.perf_config_bucket_encryption mojo-development-nac-perf-config-bucket"
+
+.PHONY: remove
+remove: ## terraform remove
+	$(DOCKER_RUN) /bin/bash -c "terraform state rm module.performance_testing.aws_s3_bucket_server_side_encryption_configuration.perf_config_bucket_encryption"

--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,9 @@ init-upgrade: ## terraform init -upgrade
 unlock: ## Terraform unblock (make unlock ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
 	$(DOCKER_RUN) /bin/bash -c "terraform force-unlock ${ID}"
 
-# .PHONY: import
-# import: ## terraform import e.g. (make import IMPORT_ARGUMENT=module.foo.bar some_resource)
-# 	$(DOCKER_RUN) /bin/bash -c "terraform import ${IMPORT_ARGUMENT}"
+.PHONY: import
+import: ## terraform import e.g. (make import IMPORT_ARGUMENT=module.foo.bar some_resource)
+	$(DOCKER_RUN) /bin/bash -c "terraform import ${IMPORT_ARGUMENT}"
 
 .PHONY: workspace-list
 workspace-list: ## terraform workspace list

--- a/Makefile
+++ b/Makefile
@@ -166,11 +166,3 @@ help:
 .PHONY: authorise-performance-test-clients
 authorise-performance-test-clients: ## Update a config file with IPs for test clients
 	$(DOCKER_RUN) /bin/bash -c "./scripts/authorise_performance_test_clients.sh"
-
-.PHONY: import
-import: ## terraform import
-	$(DOCKER_RUN) /bin/bash -c "terraform import module.performance_testing[0].aws_s3_bucket_server_side_encryption_configuration.perf_config_bucket_encryption mojo-development-nac-perf-config-bucket"
-
-.PHONY: remove
-remove: ## terraform remove
-	$(DOCKER_RUN) /bin/bash -c "terraform state rm module.performance_testing.aws_s3_bucket_server_side_encryption_configuration.perf_config_bucket_encryption"

--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,9 @@ init-upgrade: ## terraform init -upgrade
 unlock: ## Terraform unblock (make unlock ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
 	$(DOCKER_RUN) /bin/bash -c "terraform force-unlock ${ID}"
 
-.PHONY: import
-import: ## terraform import e.g. (make import IMPORT_ARGUMENT=module.foo.bar some_resource)
-	$(DOCKER_RUN) /bin/bash -c "terraform import ${IMPORT_ARGUMENT}"
+# .PHONY: import
+# import: ## terraform import e.g. (make import IMPORT_ARGUMENT=module.foo.bar some_resource)
+# 	$(DOCKER_RUN) /bin/bash -c "terraform import ${IMPORT_ARGUMENT}"
 
 .PHONY: workspace-list
 workspace-list: ## terraform workspace list
@@ -166,3 +166,7 @@ help:
 .PHONY: authorise-performance-test-clients
 authorise-performance-test-clients: ## Update a config file with IPs for test clients
 	$(DOCKER_RUN) /bin/bash -c "./scripts/authorise_performance_test_clients.sh"
+
+.PHONY: import
+import: ## terraform import
+	$(DOCKER_RUN) /bin/bash -c "terraform import module.radius.aws_s3_bucket_acl.certificate_bucket_logs_acl mojo-development-nac-certificate-bucket-logs"

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ tfenv: ## tfenv pin - terraform version from versions.tf
 
 .PHONY: taint
 taint: ## terraform taint (make taint TAINT_ARGUMENT=module.radius.aws_lb.load_balancer)
-	 taint -no-color ${TAINT_ARGUMENT}"
+	$(DOCKER_RUN) /bin/bash -c "terraform taint -no-color ${TAINT_ARGUMENT}"
 
 help:
 	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/modules/performance_testing/s3.tf
+++ b/modules/performance_testing/s3.tf
@@ -3,6 +3,18 @@ resource "aws_s3_bucket" "config_bucket" {
 
 }
 
+resource "aws_s3_bucket_acl" "perf_config_bucket_acl" {
+  bucket = aws_s3_bucket.config_bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "config_bucket_versioning" {
+  bucket = aws_s3_bucket.config_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "perf_config_bucket_encryption" {
   bucket = aws_s3_bucket.config_bucket.id
 

--- a/modules/performance_testing/s3.tf
+++ b/modules/performance_testing/s3.tf
@@ -1,15 +1,15 @@
 resource "aws_s3_bucket" "config_bucket" {
   bucket = "${var.prefix}-config-bucket"
-  acl    = "private"
-  versioning {
-    enabled = true
-  }
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.config_bucket_key.arn
-        sse_algorithm     = "aws:kms"
-      }
+
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "perf_config_bucket_encryption" {
+  bucket = aws_s3_bucket.config_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.config_bucket_key.arn
+      sse_algorithm     = "aws:kms"
     }
   }
 }

--- a/modules/radius/load_balancer.tf
+++ b/modules/radius/load_balancer.tf
@@ -114,6 +114,18 @@ resource "aws_s3_bucket" "lb_log_bucket" {
   tags = var.tags
 }
 
+resource "aws_s3_bucket_acl" "lb_log_bucket_acl" {
+  bucket = aws_s3_bucket.lb_log_bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "lb_log_bucket_versioning" {
+  bucket = aws_s3_bucket.lb_log_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "lb_log_bucket_lifecycle_policy" {
   bucket = aws_s3_bucket.lb_log_bucket.id
 

--- a/modules/radius/load_balancer.tf
+++ b/modules/radius/load_balancer.tf
@@ -110,20 +110,20 @@ resource "aws_lb_target_group" "target_group_radsec" {
 
 resource "aws_s3_bucket" "lb_log_bucket" {
   bucket = "${var.prefix}-lb-log-bucket"
-  acl    = "private"
-  versioning {
-    enabled = true
-  }
 
-  lifecycle_rule {
-    id      = "30_day_retention_lb_bucket_logs"
-    enabled = true
+  tags = var.tags
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "lb_log_bucket_lifecycle_policy" {
+  bucket = aws_s3_bucket.lb_log_bucket.id
+
+  rule {
+    id = "30_day_retention_lb_log_bucket-1"
     expiration {
       days = 30
     }
+    status = "Enabled"
   }
-
-  tags = var.tags
 }
 
 resource "aws_s3_bucket_policy" "lb_log_bucket_policy" {

--- a/modules/radius/s3.tf
+++ b/modules/radius/s3.tf
@@ -4,6 +4,26 @@ resource "aws_s3_bucket" "config_bucket" {
   tags = var.tags
 }
 
+resource "aws_s3_bucket_ownership_controls" "config_bucket_ownership" {
+  bucket = aws_s3_bucket.config_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "config_bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.config_bucket_ownership]
+  bucket     = aws_s3_bucket.config_bucket.id
+  acl        = "private"
+}
+
+resource "aws_s3_bucket_versioning" "config_bucket_versioning" {
+  bucket = aws_s3_bucket.config_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "config_bucket_encryption" {
   bucket = aws_s3_bucket.config_bucket.id
 
@@ -58,6 +78,18 @@ resource "aws_s3_bucket" "config_bucket_logs" {
   bucket = "${var.prefix}-config-bucket-logs"
 
   tags = var.tags
+}
+
+resource "aws_s3_bucket_ownership_controls" "config_bucket_logs_ownership" {
+  bucket = aws_s3_bucket.config_bucket_logs.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "config_bucket_logs_acl" {
+  bucket = aws_s3_bucket.config_bucket_logs.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "conf_log_bucket_lifecycle_policy" {

--- a/modules/radius/s3.tf
+++ b/modules/radius/s3.tf
@@ -1,15 +1,6 @@
 resource "aws_s3_bucket" "config_bucket" {
   bucket = "${var.prefix}-config-bucket"
 
-  # server_side_encryption_configuration {
-  #   rule {
-  #     apply_server_side_encryption_by_default {
-  #       kms_master_key_id = aws_kms_key.config_bucket_key.arn
-  #       sse_algorithm     = "aws:kms"
-  #     }
-  #   }
-  # }
-
   tags = var.tags
 }
 

--- a/modules/radius/s3.tf
+++ b/modules/radius/s3.tf
@@ -64,7 +64,7 @@ resource "aws_kms_key" "config_bucket_key" {
 }
 
 resource "aws_s3_bucket" "config_bucket_logs" {
-  bucket = "${var.prefix}-config-bucket-logs" 
+  bucket = "${var.prefix}-config-bucket-logs"
 
   tags = var.tags
 }

--- a/modules/radius/s3_certificates.tf
+++ b/modules/radius/s3_certificates.tf
@@ -1,15 +1,6 @@
 resource "aws_s3_bucket" "certificate_bucket" {
   bucket = "${var.prefix}-certificate-bucket"
 
-  # server_side_encryption_configuration {
-  #   rule {
-  #     apply_server_side_encryption_by_default {
-  #       kms_master_key_id = aws_kms_key.certificate_bucket_key.arn
-  #       sse_algorithm     = "aws:kms"
-  #     }
-  #   }
-  # }
-
   tags = var.tags
 }
 

--- a/modules/radius/s3_certificates.tf
+++ b/modules/radius/s3_certificates.tf
@@ -4,6 +4,18 @@ resource "aws_s3_bucket" "certificate_bucket" {
   tags = var.tags
 }
 
+resource "aws_s3_bucket_acl" "certificate_bucket_acl" {
+  bucket = aws_s3_bucket.certificate_bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "certificate_bucket_versioning" {
+  bucket = aws_s3_bucket.certificate_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "cert_bucket_encryption" {
   bucket = aws_s3_bucket.certificate_bucket.id
 
@@ -56,6 +68,11 @@ resource "aws_s3_bucket" "certificate_bucket_logs" {
   bucket = "${var.prefix}-certificate-bucket-logs"
 
   tags = var.tags
+}
+
+resource "aws_s3_bucket_acl" "certificate_bucket_logs_acl" {
+  bucket = aws_s3_bucket.certificate_bucket_logs.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "cert_log_bucket_lifecycle_policy" {


### PR DESCRIPTION
Updated s3 resources to get rid of deprecated warnings after upgrading AWS provider from 3 to 4.

Imported encryption resources, logging resources

acl and versioning not needed as they are standard on s3 buckets and don't need to be explicitly declared unless they need to be changed ie. acl from private to public, or versioning from enabled to disabled.
