### PR TITLE
Reverting Dependabot merge of Terraform version update.

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.8.5"
+  required_version = "1.1.3"
 
   required_providers {
     aws = {


### PR DESCRIPTION
We can't update from 1.1.3 to a higher version without testing and reviewing the imact of these major version upgrades.

ND-214