### PR TITLE
Align ECR retention policy with agreed policy

### DIFF
--- a/modules/admin/ecs.tf
+++ b/modules/admin/ecs.tf
@@ -28,7 +28,7 @@ resource "aws_ecr_repository_policy" "admin" {
         {
             "Sid": "1",
             "Effect": "Allow",
-            "Principal":{ 
+            "Principal":{
               "AWS": ["${data.aws_caller_identity.current.account_id}","${var.shared_services_account_id}"]
             },
             "Action": [
@@ -61,12 +61,11 @@ resource "aws_ecr_lifecycle_policy" "admin" {
     "rules": [
         {
             "rulePriority": 1,
-            "description": "Expire images older than 14 days",
+            "description": "Expire older versions of untagged images, keeping the latest 15",
             "selection": {
                 "tagStatus": "untagged",
-                "countType": "sinceImagePushed",
-                "countUnit": "days",
-                "countNumber": 14
+                "countType": "imageCountMoreThan",
+                "countNumber": 15
             },
             "action": {
                 "type": "expire"

--- a/modules/radius/ecr.tf
+++ b/modules/radius/ecr.tf
@@ -21,7 +21,7 @@ resource "aws_ecr_repository_policy" "radius" {
         {
             "Sid": "1",
             "Effect": "Allow",
-            "Principal":{ 
+            "Principal":{
               "AWS": ["${data.aws_caller_identity.current.account_id}","${var.shared_services_account_id}"]
             },
             "Action": [
@@ -54,12 +54,11 @@ resource "aws_ecr_lifecycle_policy" "radius" {
     "rules": [
         {
             "rulePriority": 1,
-            "description": "Expire images older than 14 days",
+            "description": "Expire older versions of untagged images, keeping the latest 15",
             "selection": {
                 "tagStatus": "untagged",
-                "countType": "sinceImagePushed",
-                "countUnit": "days",
-                "countNumber": 14
+                "countType": "imageCountMoreThan",
+                "countNumber": 15
             },
             "action": {
                 "type": "expire"

--- a/modules/radius/ecr_nginx.tf
+++ b/modules/radius/ecr_nginx.tf
@@ -8,7 +8,7 @@ resource "aws_ecr_repository_policy" "nginx" {
         {
             "Sid": "1",
             "Effect": "Allow",
-            "Principal":{ 
+            "Principal":{
               "AWS": ["${data.aws_caller_identity.current.account_id}","${var.shared_services_account_id}"]
             },
             "Action": [
@@ -52,12 +52,11 @@ resource "aws_ecr_lifecycle_policy" "nginx" {
     "rules": [
         {
             "rulePriority": 1,
-            "description": "Expire images older than 14 days",
+            "description": "Expire older versions of untagged images, keeping the latest 15",
             "selection": {
                 "tagStatus": "untagged",
-                "countType": "sinceImagePushed",
-                "countUnit": "days",
-                "countNumber": 14
+                "countType": "imageCountMoreThan",
+                "countNumber": 15
             },
             "action": {
                 "type": "expire"


### PR DESCRIPTION
The current policy of
"Expire images older than 14 days"
Doesn't match our agreed policy as used in DNS & DHCP services. This also creates a risk that we can't rollback to previous known good images as any image older than 14 days will be expired.

This is actually hampering ability to diagnose a possible issue with a new Radius AMI.

The new policy has been agreed with the balance of retention and ability to rollback to known  good images that might be many months old. "Expire older versions of untagged images, keeping the latest 15"

ND-463