### PR TITLE
Added service name to the secrets description

### DIFF
--- a/secrets_manager.tf
+++ b/secrets_manager.tf
@@ -9,7 +9,7 @@ locals {
 
 resource "aws_secretsmanager_secret" "moj_network_access_control_env_admin_db" {
   name        = "/moj-network-access-control/${terraform.workspace}/admin/db"
-  description = "Admin RDS Database password."
+  description = "Network Access Control - Admin RDS Database password."
   provider    = aws.env
   tags = merge(local.tags_minus_name,
     { "Name" : "/moj-network-access-control/${terraform.workspace}/admin/db" }
@@ -49,7 +49,7 @@ resource "random_password" "moj_network_access_control_env_admin_db" {
 
 resource "aws_secretsmanager_secret" "moj_network_access_control_env_admin_sentry_dsn" {
   name        = "/moj-network-access-control/${terraform.workspace}/admin/sentry_dsn"
-  description = "Sentry - Application monitoring and debugging software - Data Source Name (DSN)."
+  description = "Network Access Control - Sentry - Application monitoring and debugging software - Data Source Name (DSN)."
   provider    = aws.env
   tags = merge(local.tags_minus_name,
     { "Name" : "/moj-network-access-control/${terraform.workspace}/admin/sentry_dsn" }
@@ -69,7 +69,7 @@ resource "aws_secretsmanager_secret_version" "moj_network_access_control_env_adm
 
 resource "aws_secretsmanager_secret" "moj_network_access_control_env_eap_private_key_password" {
   name        = "/moj-network-access-control/${terraform.workspace}/eap/private_key_password"
-  description = "Radius Extended Access Protocol (EAP) - private key password"
+  description = "Network Access Control - Radius Extended Access Protocol (EAP) - private key password"
   provider    = aws.env
   tags = merge(local.tags_minus_name,
     { "Name" : "/moj-network-access-control/${terraform.workspace}/eap/private_key_password" }
@@ -89,7 +89,7 @@ resource "aws_secretsmanager_secret_version" "moj_network_access_control_env_eap
 
 resource "aws_secretsmanager_secret" "moj_network_access_control_env_radsec_private_key_password" {
   name        = "/moj-network-access-control/${terraform.workspace}/radsec/private_key_password"
-  description = "Radius RadSec TLS - private key password."
+  description = "Network Access Control - Radius RadSec TLS - private key password."
   provider    = aws.env
   tags = merge(local.tags_minus_name,
     { "Name" : "/moj-network-access-control/${terraform.workspace}/radsec/private_key_password" }

--- a/secrets_manager.tf
+++ b/secrets_manager.tf
@@ -8,8 +8,9 @@ locals {
 }
 
 resource "aws_secretsmanager_secret" "moj_network_access_control_env_admin_db" {
-  name     = "/moj-network-access-control/${terraform.workspace}/admin/db"
-  provider = aws.env
+  name        = "/moj-network-access-control/${terraform.workspace}/admin/db"
+  description = "Admin RDS Database password."
+  provider    = aws.env
   tags = merge(local.tags_minus_name,
     { "Name" : "/moj-network-access-control/${terraform.workspace}/admin/db" }
   )
@@ -47,8 +48,9 @@ resource "random_password" "moj_network_access_control_env_admin_db" {
 }
 
 resource "aws_secretsmanager_secret" "moj_network_access_control_env_admin_sentry_dsn" {
-  name     = "/moj-network-access-control/${terraform.workspace}/admin/sentry_dsn"
-  provider = aws.env
+  name        = "/moj-network-access-control/${terraform.workspace}/admin/sentry_dsn"
+  description = "Sentry - Application monitoring and debugging software - Data Source Name (DSN)."
+  provider    = aws.env
   tags = merge(local.tags_minus_name,
     { "Name" : "/moj-network-access-control/${terraform.workspace}/admin/sentry_dsn" }
   )
@@ -66,8 +68,9 @@ resource "aws_secretsmanager_secret_version" "moj_network_access_control_env_adm
 }
 
 resource "aws_secretsmanager_secret" "moj_network_access_control_env_eap_private_key_password" {
-  name     = "/moj-network-access-control/${terraform.workspace}/eap/private_key_password"
-  provider = aws.env
+  name        = "/moj-network-access-control/${terraform.workspace}/eap/private_key_password"
+  description = "Radius Extended Access Protocol (EAP) - private key password"
+  provider    = aws.env
   tags = merge(local.tags_minus_name,
     { "Name" : "/moj-network-access-control/${terraform.workspace}/eap/private_key_password" }
   )
@@ -85,8 +88,9 @@ resource "aws_secretsmanager_secret_version" "moj_network_access_control_env_eap
 }
 
 resource "aws_secretsmanager_secret" "moj_network_access_control_env_radsec_private_key_password" {
-  name     = "/moj-network-access-control/${terraform.workspace}/radsec/private_key_password"
-  provider = aws.env
+  name        = "/moj-network-access-control/${terraform.workspace}/radsec/private_key_password"
+  description = "Radius RadSec TLS - private key password."
+  provider    = aws.env
   tags = merge(local.tags_minus_name,
     { "Name" : "/moj-network-access-control/${terraform.workspace}/radsec/private_key_password" }
   )


### PR DESCRIPTION
When other secrets have their descriptions added this will be necessary.

Also some secrets name/path have unhelpful legacy information in them which is misleading and the combination of a good description and AWS resources tag will help greatly in making the use clearer.

ND-398