### PR TITLE
amended owner email in tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ module "label" {
     "business-unit"    = "HQ"
     "application"      = "network-access-control"
     "is-production"    = tostring(local.is_production)
-    "owner"            = "nac@digital.justice.gov.uk"
+    "owner"            = "lanwifi-devops@digital.justice.gov.uk"
     "environment-name" = "global"
     "source-code"      = "https://github.com/ministryofjustice/network-access-control-infrastructure"
   }


### PR DESCRIPTION
Owner email in tags was outdated and the email wasn't in use. 

Changed to lanwifi-devops@digital.justice.gov.uk which is monitored.