### PR TITLE
Added vpc route for nhs oxlease

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -169,3 +169,7 @@ data "aws_ssm_parameter" "ocsp_dhl_ip" {
 data "aws_ssm_parameter" "ocsp_dhl_failover_ip" {
   name = "/moj-network-access-control/${terraform.workspace}/ocsp_dhl_failover_ip"
 }
+
+data "aws_ssm_parameter" "ocsp_nhs_oxleas_ip" {
+  name = "/moj-network-access-control/${terraform.workspace}/ocsp_nhs_oxleas_ip"
+}

--- a/locals.tf
+++ b/locals.tf
@@ -36,6 +36,7 @@ locals {
   ocsp_prs_ip                     = nonsensitive(data.aws_ssm_parameter.ocsp_prs_ip.value)
   ocsp_dhl_ip                     = nonsensitive(data.aws_ssm_parameter.ocsp_dhl_ip.value)
   ocsp_dhl_failover_ip            = nonsensitive(data.aws_ssm_parameter.ocsp_dhl_failover_ip.value)
+  ocsp_nhs_oxleas_ip              = nonsensitive(data.aws_ssm_parameter.ocsp_nhs_oxleas_ip.value)
   enable_ocsp                     = data.aws_ssm_parameter.enable_ocsp.value
   ocsp_override_cert_url          = data.aws_ssm_parameter.ocsp_override_cert_url.value
   byoip_pool_id                   = nonsensitive(data.aws_ssm_parameter.byoip_pool_id.value)

--- a/modules/vpc/routes.tf
+++ b/modules/vpc/routes.tf
@@ -111,6 +111,18 @@ resource "aws_route" "nat-gateway-public-ocsp-endpoint-4" {
   ]
 }
 
+resource "aws_route" "nat-gateway-public-ocsp-endpoint-5" {
+  count = length(module.vpc.public_route_table_ids)
+
+  route_table_id         = split("_", local.public_table_id)[count.index]
+  destination_cidr_block = "${var.ocsp_nhs_oxleas_ip}/32"
+  nat_gateway_id         = aws_nat_gateway.eu_west_2c.id
+
+  depends_on = [
+    module.vpc
+  ]
+}
+
 resource "aws_nat_gateway" "eu_west_2c" {
   allocation_id = aws_eip.nat_eu_west_2c.id
   subnet_id     = element(module.vpc.private_subnets, 2)

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -71,3 +71,7 @@ variable "ocsp_dhl_ip" {
 variable "ocsp_dhl_failover_ip" {
   type = string
 }
+
+variable "ocsp_nhs_oxleas_ip" {
+  type = string
+}

--- a/vpc_radius.tf
+++ b/vpc_radius.tf
@@ -15,7 +15,7 @@ module "radius_vpc" {
   ocsp_prs_ip                           = local.ocsp_prs_ip
   ocsp_dhl_ip                           = local.ocsp_dhl_ip
   ocsp_dhl_failover_ip                  = local.ocsp_dhl_failover_ip
-  ocsp_nhs_oxleas_ip                    = local.ocsp_nhs_oxlease_ip
+  ocsp_nhs_oxleas_ip                    = local.ocsp_nhs_oxleas_ip
   tags                                  = module.label.tags
   providers = {
     aws = aws.env

--- a/vpc_radius.tf
+++ b/vpc_radius.tf
@@ -15,6 +15,7 @@ module "radius_vpc" {
   ocsp_prs_ip                           = local.ocsp_prs_ip
   ocsp_dhl_ip                           = local.ocsp_dhl_ip
   ocsp_dhl_failover_ip                  = local.ocsp_dhl_failover_ip
+  ocsp_nhs_oxleas_ip                    = local.ocsp_nhs_oxlease_ip
   tags                                  = module.label.tags
   providers = {
     aws = aws.env


### PR DESCRIPTION
NACs Public route table updated to reflect NHS Oxlease OCSP endpoint to be routed via NAT

